### PR TITLE
updated error message for passkey to be more generic, added a generic…

### DIFF
--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -48,7 +48,7 @@ export interface AuthContextType {
   credentials: Credential[];
   updateCredential: (credential: Credential) => Promise<Credential>;
   deleteCredential: (credentialId: string) => Promise<void>;
-  login: (identifier: string, passkeyAvailable: boolean) => Promise<Response>;
+  login: (identifier: string, passkeyAvailable: boolean) => Promise<Response | null>;
   handlePasskeyLogin: () => Promise<boolean>;
   loading: boolean;
 }
@@ -109,13 +109,19 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   const login = async (
     identifier: string,
     passkeyAvailable: boolean
-  ): Promise<Response> => {
-    const response = await fetchWithAuth(`/login`, {
-      method: 'POST',
-      body: JSON.stringify({ identifier, passkeyAvailable }),
-    });
+  ): Promise<Response | null> => {
+    console.log('oranges');
 
-    return response;
+    try {
+      const response = await fetchWithAuth(`/login`, {
+        method: 'POST',
+        body: JSON.stringify({ identifier, passkeyAvailable }),
+      });
+      return response;
+    } catch (error) {
+      console.error('Error fetching,', error);
+      return null;
+    }
   };
 
   const handlePasskeyLogin = async () => {

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -110,8 +110,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     identifier: string,
     passkeyAvailable: boolean
   ): Promise<Response | null> => {
-    console.log('oranges');
-
     try {
       const response = await fetchWithAuth(`/login`, {
         method: 'POST',

--- a/src/components/AuthFallbackOptions.tsx
+++ b/src/components/AuthFallbackOptions.tsx
@@ -27,7 +27,7 @@ const AuthFallbackOptions: React.FC<AuthFallbackOptionsProps> = ({
 
   return (
     <div className={styles.fallbackCard}>
-      <div className={styles.fallbackHeader}>Passkeys unavailable on this device</div>
+      <div className={styles.fallbackHeader}>Trouble with passkey login?</div>
 
       <p className={styles.fallbackDescription}>Choose another secure sign-in method.</p>
 

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -155,12 +155,14 @@ const Login: React.FC = () => {
     if (mode === 'login') {
       const loginRes = await login(identifier, passkeyAvailable);
 
-      if (loginRes.ok && passkeyAvailable) {
+      if (loginRes && loginRes.ok && passkeyAvailable) {
         const passkeyResult = await handlePasskeyLogin();
+
         if (passkeyResult) {
           navigate('/');
         }
       } else {
+        setIdentifierError('An error occurred');
         setShowFallbackOptions(true);
       }
     }


### PR DESCRIPTION
… error text when trying to login with bad account

## Summary
There was no error message when trying to login with a bad account. 

Describe the change.

Added some code to check if the response is okay, if not update the error message to show a generic response.
## Type of Change

- [ x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Test

## Checklist

- [ ] Tests pass
- [ x] No breaking changes
- [ ] Docs updated (if needed)
- [ ] Security implications considered
