### PR TITLE
fix: register with just an email

### DIFF
--- a/.changeset/email-first-registration.md
+++ b/.changeset/email-first-registration.md
@@ -1,0 +1,9 @@
+---
+"@seamless-auth/react": patch
+---
+
+Register with just an email. The registration form no longer requires a phone
+number (it stays optional, validated only when provided), and a successful
+registration now routes to email verification (`/verifyEmailOTP`) instead of
+phone verification — matching the auth server's email-first registration. After
+verifying the email code the user is signed in.

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -76,7 +76,9 @@ const Login: React.FC = () => {
       return isValidEmail(identifier) || isValidPhoneNumber(identifier);
     }
 
-    return isValidEmail(email) && isValidPhoneNumber(phone);
+    // Registration starts with just an email; a phone is optional but, if given,
+    // must be valid.
+    return isValidEmail(email) && (!phone || isValidPhoneNumber(phone));
   };
 
   const register = async () => {
@@ -97,7 +99,7 @@ const Login: React.FC = () => {
       const data = await response.json();
 
       if (data.message === 'Success') {
-        navigate('/verifyPhoneOTP');
+        navigate('/verifyEmailOTP');
         return;
       }
       setFormErrors(

--- a/tests/login.test.tsx
+++ b/tests/login.test.tsx
@@ -293,6 +293,6 @@ describe('Login', () => {
       fireEvent.click(registerButton);
     });
 
-    expect(navigate).toHaveBeenCalledWith('/verifyPhoneOTP');
+    expect(navigate).toHaveBeenCalledWith('/verifyEmailOTP');
   });
 });


### PR DESCRIPTION
## What

Let users register with just an email, matching the auth server's email-first
registration flow.

## Why

Registration required both email **and** phone, and a successful register navigated to
`/verifyPhoneOTP` — but the server sends an *email* OTP on registration and (now) issues
the session once the email is verified. The phone-first UI left users stranded on a phone
screen with no SMS sent. (Surfaced by the `seamless verify` conformance harness.)

## Changes

- Phone is optional on the registration form (validated only when provided).
- A successful registration routes to `/verifyEmailOTP`; verifying the email code signs
  the user in.
- Update the register unit test for the new navigation target.

## Verification

`npx jest` green (147 tests). `seamless verify --local` green, including a new browser case:
`register with just an email -> verify email OTP -> signed in`.

Pairs with fells-code/seamless-auth-server (registration session cookies).
