### PR TITLE
docs: correct package name in LICENSE.md summary

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # License
 
-Seamless Auth Server - Express ("@seamlessauth/express") is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0-only)**.
+`@seamless-auth/react` is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0-only)**.
 
 - SPDX: `AGPL-3.0-only`
 
@@ -21,6 +21,6 @@ You should include a copy of the AGPLv3 license in your distribution. If this re
 
 ## Commercial licensing
 
-If you would like to embed Seamless Auth API into a proprietary product, redistribute it under different terms, or offer it as a managed service without AGPL obligations, commercial licensing may be available.
+If you would like to embed `@seamless-auth/react` into a proprietary product, redistribute it under different terms, or offer it as a managed service without AGPL obligations, commercial licensing may be available.
 
 Contact: support@seamlessauth.com


### PR DESCRIPTION
## What

Correct the package name in the `LICENSE.md` human-friendly summary. It previously read "Seamless Auth Server - Express (`@seamlessauth/express`)" and referenced "Seamless Auth API", both copied from another repo. It now references `@seamless-auth/react`.

## Why

The summary named the wrong product and an invalid npm scope in a public-facing file for a security package.

Closes #53.

## Notes

- `LICENSE.md` is a repo-only summary and is not part of the published package `files`, so no changeset is included (not adopter-facing in the npm artifact). The full `LICENSE` (AGPL-3.0 text) is unchanged and remains the authoritative shipped license.

## Checks

- `npx prettier --check LICENSE.md` passes
- Full test suite runs via the pre-commit hook: 158 passed
