### PR TITLE
fix(magic-link): refresh session in the verifying tab after success

### DIFF
--- a/.changeset/magic-link-refresh-session.md
+++ b/.changeset/magic-link-refresh-session.md
@@ -1,0 +1,5 @@
+---
+'@seamless-auth/react': patch
+---
+
+Fix magic-link verification so the tab that completes the link refreshes provider state and lands authenticated, instead of relying on another tab or a manual reload.

--- a/src/views/VerifyMagicLink.tsx
+++ b/src/views/VerifyMagicLink.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { useAuth } from '@/AuthProvider';
 import { useAuthClient } from '@/hooks/useAuthClient';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
@@ -19,6 +20,7 @@ const VerifyMagicLink: React.FC = () => {
   const [successMsg, setSuccessMsg] = useState('');
 
   const authClient = useAuthClient();
+  const { refreshSession } = useAuth();
 
   useEffect(() => {
     let mounted = true;
@@ -44,6 +46,11 @@ const VerifyMagicLink: React.FC = () => {
           }
           return;
         }
+
+        // The verify call sets the session cookie for this browser. Sync
+        // provider state here so the tab that completed verification lands
+        // authenticated instead of relying on another tab or a manual reload.
+        await refreshSession();
       } catch {
         console.error('Failed to verify magic-link token.');
       }
@@ -80,7 +87,7 @@ const VerifyMagicLink: React.FC = () => {
         clearTimeout(redirectTimeout);
       }
     };
-  }, [token, authClient, navigate]);
+  }, [token, authClient, navigate, refreshSession]);
 
   return (
     <div className={styles.container}>

--- a/tests/VerifyMagicLink.test.tsx
+++ b/tests/VerifyMagicLink.test.tsx
@@ -7,11 +7,13 @@
 import { render, screen, act } from '@testing-library/react';
 import VerifyMagicLink from '@/views/VerifyMagicLink';
 
+import { useAuth } from '@/AuthProvider';
 import { useAuthClient } from '@/hooks/useAuthClient';
 
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 jest.mock('@/hooks/useAuthClient');
+jest.mock('@/AuthProvider');
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -21,6 +23,7 @@ jest.mock('react-router-dom', () => ({
 
 describe('VerifyMagicLink', () => {
   const navigate = jest.fn();
+  const refreshSession = jest.fn().mockResolvedValue(undefined);
   const mockAuthClient = {
     verifyMagicLink: jest.fn(),
   };
@@ -32,6 +35,7 @@ describe('VerifyMagicLink', () => {
 
     (useNavigate as jest.Mock).mockReturnValue(navigate);
     (useAuthClient as jest.Mock).mockReturnValue(mockAuthClient);
+    (useAuth as jest.Mock).mockReturnValue({ refreshSession });
 
     global.BroadcastChannel = jest.fn(() => ({
       postMessage,
@@ -119,6 +123,38 @@ describe('VerifyMagicLink', () => {
     });
 
     expect(navigate).toHaveBeenCalledWith('/');
+  });
+
+  test('refreshes provider session on successful verification', async () => {
+    (useSearchParams as jest.Mock).mockReturnValue([
+      new URLSearchParams('?token=abc123'),
+    ]);
+
+    mockAuthClient.verifyMagicLink.mockResolvedValue({
+      ok: true,
+    });
+
+    render(<VerifyMagicLink />);
+
+    await screen.findByText(/login verified/i);
+
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not refresh session when verification fails', async () => {
+    (useSearchParams as jest.Mock).mockReturnValue([
+      new URLSearchParams('?token=abc123'),
+    ]);
+
+    mockAuthClient.verifyMagicLink.mockResolvedValue({
+      ok: false,
+    });
+
+    render(<VerifyMagicLink />);
+
+    await screen.findByText(/failed to verify token/i);
+
+    expect(refreshSession).not.toHaveBeenCalled();
   });
 
   test('cleans up broadcast channel and redirect timeout on unmount', async () => {


### PR DESCRIPTION
## What

`VerifyMagicLink` now calls `refreshSession()` (from `useAuth()`) after a successful token verify, before broadcasting and redirecting.

## Why

The verifying tab set the session cookie but never refreshed its own provider state. Because a magic link usually opens a fresh tab, `AuthProvider` runs `validateToken()` on mount and 401s before the cookie exists, then the effect sets the cookie but nothing re-validates, so `navigate('/')` lands the user unauthenticated until a manual reload. Only the original tab (via the `BroadcastChannel` listener and polling in `MagicLinkSent`) actually authenticated. This makes the tab that completed verification reflect the new session directly.

Closes #54.

## Changes

- `src/views/VerifyMagicLink.tsx`: consume `useAuth()` and `await refreshSession()` on the success path only (a failed verify does not refresh).
- `tests/VerifyMagicLink.test.tsx`: mock `@/AuthProvider`, assert `refreshSession` runs on success and not on failure.
- Changeset (patch): adopter-facing behavior fix.

## Checks

- `eslint` clean on the changed files
- Full test suite via pre-commit hook: 160 passed (2 new)
- `prettier --check` clean
