### PR TITLE
fix(passkey): remove dead mfaLogin login branch and mfaRequired field

### DIFF
--- a/.changeset/remove-passkey-mfa-required.md
+++ b/.changeset/remove-passkey-mfa-required.md
@@ -1,0 +1,7 @@
+---
+'@seamless-auth/react': minor
+---
+
+Remove the unused `mfaRequired` field from `PasskeyLoginResult` (and the inherited `PasskeyLoginWithPrfResult`). The backend never gated passkey login on a second factor, so the field was always `false` and the related fail-closed path in `handlePasskeyLogin` was dead code.
+
+BREAKING: consumers reading `result.mfaRequired` from `loginWithPasskey()` should remove that check. A successful passkey login is now indicated solely by `result.success`.

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -114,13 +114,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   const handlePasskeyLogin = async () => {
     const result = await authClient.loginWithPasskey();
 
-    if (result.mfaRequired) {
-      console.warn(
-        'Passkey login requested MFA, but the built-in MFA route is not currently available.'
-      );
-      return false;
-    }
-
     if (result.success) {
       await validateToken();
       return true;

--- a/src/client/createSeamlessAuthClient.ts
+++ b/src/client/createSeamlessAuthClient.ts
@@ -130,7 +130,6 @@ export interface FinishOAuthLoginInput {
 
 export interface PasskeyLoginResult {
   success: boolean;
-  mfaRequired: boolean;
   message: string;
 }
 
@@ -338,7 +337,6 @@ export const createSeamlessAuthClient = (
       if (!response.ok) {
         return {
           success: false,
-          mfaRequired: false,
           message: 'Failed to start passkey login.',
         };
       }
@@ -359,7 +357,6 @@ export const createSeamlessAuthClient = (
         if (!verificationResponse.ok) {
           return {
             success: false,
-            mfaRequired: false,
             message: 'Failed to verify passkey.',
           };
         }
@@ -368,25 +365,20 @@ export const createSeamlessAuthClient = (
 
         if (verificationResult.message === 'Success') {
           return {
-            success: !verificationResult.mfaLogin,
-            mfaRequired: Boolean(verificationResult.mfaLogin),
-            message: verificationResult.mfaLogin
-              ? 'Passkey login requires MFA.'
-              : 'Passkey login succeeded.',
+            success: true,
+            message: 'Passkey login succeeded.',
             ...(prf ? { prf } : {}),
           };
         }
 
         return {
           success: false,
-          mfaRequired: false,
           message: verificationResult.message ?? 'Passkey login failed.',
         };
       } catch {
         console.error('Passkey login error.');
         return {
           success: false,
-          mfaRequired: false,
           message: 'Passkey login failed.',
         };
       }

--- a/tests/createSeamlessAuthClient.test.ts
+++ b/tests/createSeamlessAuthClient.test.ts
@@ -241,7 +241,7 @@ describe('createSeamlessAuthClient', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ message: 'Success', mfaLogin: false }),
+        json: async () => ({ message: 'Success' }),
       });
     (startAuthentication as jest.Mock).mockResolvedValueOnce({ credential: 'assertion' });
 
@@ -251,7 +251,6 @@ describe('createSeamlessAuthClient', () => {
 
     await expect(client.loginWithPasskey()).resolves.toEqual({
       success: true,
-      mfaRequired: false,
       message: 'Passkey login succeeded.',
     });
   });
@@ -273,7 +272,7 @@ describe('createSeamlessAuthClient', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ message: 'Success', mfaLogin: false }),
+        json: async () => ({ message: 'Success' }),
       });
     (startAuthentication as jest.Mock).mockResolvedValueOnce({
       id: 'cred-prf',

--- a/tests/login.test.tsx
+++ b/tests/login.test.tsx
@@ -76,7 +76,7 @@ describe('Login', () => {
 
     mockAuthClient.register.mockResolvedValue({
       ok: true,
-      json: async () => ({ message: 'Success', mfaLogin: false }),
+      json: async () => ({ message: 'Success' }),
     });
     mockAuthClient.requestMagicLink.mockResolvedValue({ ok: true });
     mockAuthClient.requestPhoneOtp.mockResolvedValue({ ok: true });


### PR DESCRIPTION
## What

Remove the dead `mfaLogin` branch from `loginWithPasskey` and the unused `mfaRequired` field from the passkey login result types, along with the fail-closed MFA path in `handlePasskeyLogin`.

## Why

The backend never gates passkey login on a second factor (TOTP is step-up only), so `verificationResult.mfaLogin` was never sent, `mfaRequired` was always `false`, and the `handlePasskeyLogin` branch that logged "the built-in MFA route is not currently available" was unreachable. The wire field name (`mfaLogin`) also did not match the public type field (`mfaRequired`), which was a fragile, undocumented coupling.

Closes #55.

## Changes

- `src/client/createSeamlessAuthClient.ts`: drop `mfaRequired` from `PasskeyLoginResult`; success is now `verificationResult.message === 'Success'`; remove `mfaRequired` from every returned object and the `mfaLogin` reads.
- `src/AuthProvider.tsx`: remove the dead `result.mfaRequired` branch in `handlePasskeyLogin`.
- Tests updated to the new result shape; stray `mfaLogin` mock fields removed.
- Changeset (minor): documents the breaking removal of `mfaRequired`.

## Breaking change

Consumers reading `result.mfaRequired` from `loginWithPasskey()` should remove that check. A successful passkey login is now indicated solely by `result.success`. `PasskeyLoginWithPrfResult` inherits the change. Marked minor per the pre-1.0 changeset policy.

## Checks

- `tsc --noEmit` clean
- `eslint ./src ./tests` clean
- Full test suite via pre-commit hook: 160 passed
- `prettier --check` clean
