### PR TITLE
ci: add PR star check workflow

### DIFF
--- a/.github/workflows/pr-star-check.yml
+++ b/.github/workflows/pr-star-check.yml
@@ -1,0 +1,75 @@
+name: PR Star Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  require-star:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check contributor has starred repository
+        env:
+          CONTRIBUTOR: ${{ github.event.pull_request.user.login }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$CONTRIBUTOR" == *"[bot]" ]]; then
+            echo "Bot pull request detected; skipping star requirement."
+            exit 0
+          fi
+
+          page=1
+          found=0
+
+          while true; do
+            response="$(curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/users/${CONTRIBUTOR}/starred?per_page=100&page=${page}")"
+
+            count="$(node -e '
+              const fs = require("fs");
+              const data = JSON.parse(fs.readFileSync(0, "utf8"));
+              console.log(Array.isArray(data) ? data.length : 0);
+            ' <<<"$response")"
+
+            match="$(node -e '
+              const fs = require("fs");
+              const [owner, repo] = process.argv.slice(1);
+              const data = JSON.parse(fs.readFileSync(0, "utf8"));
+              const found = Array.isArray(data) && data.some((item) =>
+                item?.owner?.login?.toLowerCase() === owner.toLowerCase() &&
+                item?.name?.toLowerCase() === repo.toLowerCase(),
+              );
+              console.log(found ? "1" : "0");
+            ' "$OWNER" "$REPO" <<<"$response")"
+
+            if [[ "$match" == "1" ]]; then
+              found=1
+              break
+            fi
+
+            if [[ "$count" -lt 100 ]]; then
+              break
+            fi
+
+            page=$((page + 1))
+          done
+
+          if [[ "$found" == "1" ]]; then
+            echo "${CONTRIBUTOR} has starred ${OWNER}/${REPO}."
+            exit 0
+          fi
+
+          echo "::error title=Repository star required::Please star ${OWNER}/${REPO} before opening a pull request."
+          exit 1


### PR DESCRIPTION
## What

Add a `PR Star Check` GitHub Actions workflow, mirroring the one already used in `seamless-auth-api`. On every pull request it verifies the author has starred this repository, and fails with a friendly message asking them to star it if they have not.

## Why

Encourages contributors to star the project, which helps growth. Keeping it identical to the `seamless-auth-api` workflow means one consistent behavior across the ecosystem.

## Details

- Triggers on `opened`, `reopened`, `synchronize`, and `ready_for_review`.
- Skips bot authors.
- Pages through the author's public stars via the GitHub API and matches `owner/repo` from the workflow context, so it is drop-in with no repo-specific values.
- `permissions: contents: read` only.
- File is byte-for-byte identical to `seamless-auth-api/.github/workflows/pr-star-check.yml`.

## Note

Because `pull_request` workflows run from the PR branch, this check runs on this PR too. It reads the author's public stars, so if the author has not publicly starred `fells-code/seamless-auth-react`, the check will report failure here. That is cosmetic for a maintainer merge and matches the api repo behavior.
