### PR TITLE
docs: align contributing node version with node 24 baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,9 +261,9 @@ The workflow:
 Do not create release tags manually for normal releases. The workflow owns stable package tags after
 the reviewed release PR is merged.
 
-The package runtime still supports Node 20, but release automation runs on Node 24 in GitHub
-Actions. If you need to run release commands locally, use Node 24.10 or newer so it matches the
-release workflow.
+This package targets a Node 24 baseline. The `engines` field requires Node 24 (`>=24.0.0 <25.0.0`),
+`.nvmrc` pins 24, and both CI and release automation run on Node 24 in GitHub Actions. Use Node 24.10
+or newer locally so development and release commands match the workflows.
 
 ### npm Publishing
 


### PR DESCRIPTION
## What

Reword the Node version paragraph in CONTRIBUTING.md to match the Node 24 baseline the repo actually enforces.

## Why

CONTRIBUTING.md stated "The package runtime still supports Node 20", but `engines.node` is `>=24.0.0 <25.0.0`, `.nvmrc` pins `24`, and CI and release automation both run on Node 24. The Node 20 claim was stale from before the Node 24 baseline was adopted, and `engines` would warn or block a Node 20 install, contradicting the doc.

Closes #57.

## Approach

Aligned the docs to the enforced baseline (Node 24) rather than widening `engines` back to Node 20, since the Node 24 baseline was adopted deliberately.

## Checks

- `prettier --check CONTRIBUTING.md` clean
- Docs-only change; full test suite still runs via pre-commit hook: 160 passed
