### PR TITLE
refactor: consolidate webauthn capability checks into one module

### DIFF
--- a/src/client/webauthnPrf.ts
+++ b/src/client/webauthnPrf.ts
@@ -6,11 +6,12 @@
 
 import {
   base64URLStringToBuffer,
-  browserSupportsWebAuthn,
   bufferToBase64URLString,
   type AuthenticationResponseJSON,
   type PublicKeyCredentialRequestOptionsJSON,
 } from '@simplewebauthn/browser';
+
+import { isWebAuthnAvailable } from './webauthnSupport';
 
 export type PasskeyPrfSalt = ArrayBuffer | ArrayBufferView | string;
 
@@ -96,19 +97,7 @@ export function createPrfRequestBody(input: PasskeyPrfInput) {
 }
 
 export async function isPasskeyPrfSupported(): Promise<boolean> {
-  if (!browserSupportsWebAuthn()) {
-    return false;
-  }
-
-  if (typeof window !== 'undefined' && window.isSecureContext === false) {
-    return false;
-  }
-
-  return (
-    typeof globalThis.PublicKeyCredential !== 'undefined' &&
-    typeof navigator !== 'undefined' &&
-    typeof navigator.credentials?.get === 'function'
-  );
+  return isWebAuthnAvailable();
 }
 
 export function preparePrfRequestOptions(

--- a/src/client/webauthnSupport.ts
+++ b/src/client/webauthnSupport.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ */
+
+import { browserSupportsWebAuthn } from '@simplewebauthn/browser';
+
+/**
+ * True when the browser exposes a usable WebAuthn API in a secure context.
+ * This is the coarse gate for any passkey flow, including PRF assertions.
+ */
+export function isWebAuthnAvailable(): boolean {
+  if (!browserSupportsWebAuthn()) {
+    return false;
+  }
+
+  if (typeof window !== 'undefined' && window.isSecureContext === false) {
+    return false;
+  }
+
+  return (
+    typeof globalThis.PublicKeyCredential !== 'undefined' &&
+    typeof navigator !== 'undefined' &&
+    typeof navigator.credentials?.get === 'function'
+  );
+}
+
+/**
+ * True when a user-verifying platform authenticator (Touch ID, Windows Hello,
+ * and similar) can be used on this device.
+ */
+export async function isPlatformAuthenticatorAvailable(): Promise<boolean> {
+  if (
+    window.PublicKeyCredential &&
+    typeof window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable ===
+      'function'
+  ) {
+    try {
+      return await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
+    } catch {
+      console.error('Error checking passkey support.');
+      return false;
+    }
+  }
+
+  return false;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,8 @@
  */
 
 import parsePhoneNumberFromString from 'libphonenumber-js';
+
+import { isPlatformAuthenticatorAvailable } from '@/client/webauthnSupport';
 /**
  * isValidEmail
  *
@@ -70,19 +72,7 @@ export const isValidPhoneNumber = (phone: string): boolean => {
  * @returns {boolean} - If the current context supports passkeys
  */
 export async function isPasskeySupported(): Promise<boolean> {
-  if (
-    window.PublicKeyCredential &&
-    typeof window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable ===
-      'function'
-  ) {
-    try {
-      return await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
-    } catch {
-      console.error('Error checking passkey support.');
-      return false;
-    }
-  }
-  return false;
+  return isPlatformAuthenticatorAvailable();
 }
 
 export function parseUserAgent() {

--- a/tests/webauthnSupport.test.ts
+++ b/tests/webauthnSupport.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ */
+
+import { browserSupportsWebAuthn } from '@simplewebauthn/browser';
+
+import {
+  isPlatformAuthenticatorAvailable,
+  isWebAuthnAvailable,
+} from '@/client/webauthnSupport';
+
+jest.mock('@simplewebauthn/browser', () => ({
+  browserSupportsWebAuthn: jest.fn(),
+}));
+
+const mockBrowserSupportsWebAuthn = browserSupportsWebAuthn as jest.Mock;
+
+describe('isWebAuthnAvailable', () => {
+  const originalPublicKeyCredential = (global as any).PublicKeyCredential;
+  const originalIsSecureContext = window.isSecureContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBrowserSupportsWebAuthn.mockReturnValue(true);
+    (global as any).PublicKeyCredential = function PublicKeyCredential() {};
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, 'credentials', {
+      configurable: true,
+      value: { get: jest.fn() },
+    });
+  });
+
+  afterEach(() => {
+    (global as any).PublicKeyCredential = originalPublicKeyCredential;
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: originalIsSecureContext,
+    });
+  });
+
+  it('returns true when WebAuthn is usable in a secure context', () => {
+    expect(isWebAuthnAvailable()).toBe(true);
+  });
+
+  it('returns false when the browser does not support WebAuthn', () => {
+    mockBrowserSupportsWebAuthn.mockReturnValue(false);
+    expect(isWebAuthnAvailable()).toBe(false);
+  });
+
+  it('returns false in an insecure context', () => {
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: false,
+    });
+    expect(isWebAuthnAvailable()).toBe(false);
+  });
+
+  it('returns false when PublicKeyCredential is missing', () => {
+    delete (global as any).PublicKeyCredential;
+    expect(isWebAuthnAvailable()).toBe(false);
+  });
+});
+
+describe('isPlatformAuthenticatorAvailable', () => {
+  const originalPublicKeyCredential = (global as any).PublicKeyCredential;
+
+  afterEach(() => {
+    (global as any).PublicKeyCredential = originalPublicKeyCredential;
+    jest.restoreAllMocks();
+  });
+
+  it('resolves the platform authenticator result', async () => {
+    (global as any).PublicKeyCredential = {
+      isUserVerifyingPlatformAuthenticatorAvailable: jest.fn().mockResolvedValue(true),
+    };
+    await expect(isPlatformAuthenticatorAvailable()).resolves.toBe(true);
+  });
+
+  it('returns false and logs when the check throws', async () => {
+    (global as any).PublicKeyCredential = {
+      isUserVerifyingPlatformAuthenticatorAvailable: jest
+        .fn()
+        .mockRejectedValue(new Error('boom')),
+    };
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(isPlatformAuthenticatorAvailable()).resolves.toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Error checking passkey support.')
+    );
+  });
+
+  it('returns false when PublicKeyCredential is missing', async () => {
+    delete (global as any).PublicKeyCredential;
+    await expect(isPlatformAuthenticatorAvailable()).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Consolidate the two hand-rolled WebAuthn capability checks into one module, `src/client/webauthnSupport.ts`, so they cannot drift.

- `isWebAuthnAvailable()`: coarse gate (WebAuthn API present, secure context, `navigator.credentials.get`). This is the logic that previously lived inline in `isPasskeyPrfSupported`.
- `isPlatformAuthenticatorAvailable()`: user-verifying platform authenticator check (Touch ID, Windows Hello). This is the logic that previously lived in `utils.isPasskeySupported`.

`webauthnPrf.isPasskeyPrfSupported()` and `utils.isPasskeySupported()` now delegate to these shared helpers.

## Why

The same capability detection was implemented in two files (`src/utils.ts` and `src/client/webauthnPrf.ts`) with slightly different logic and no shared source of truth, so they could drift. Centralizing them removes that risk and names each check for what it actually detects.

Closes #59.

## Behavior and API

- No public API change: `isPasskeyPrfSupported` keeps its name, location, signature, and behavior (still exported from `src/index.ts`).
- No behavior change: both delegating functions preserve their exact previous semantics, including the `console.error` on the platform-authenticator check.
- The new helpers are internal (not exported from `src/index.ts`).
- No changeset: internal refactor with no adopter-facing effect.

## Tests

- New `tests/webauthnSupport.test.ts` covers both helpers, including the previously untested `isWebAuthnAvailable` (insecure context, missing `PublicKeyCredential`, unsupported browser). `webauthnSupport.ts` is at 100% coverage.
- Existing `utils` / `usePasskeySupport` / client tests unchanged and green.

## Checks

- `npm run typecheck` clean
- `npm run lint` clean
- `npm run format:check` clean
- Full suite via pre-commit hook: 167 passed (7 new)
