### PR TITLE
fix(fetch): skip content-type on bodyless requests and drop non-ok warn

### DIFF
--- a/.changeset/fetchwithauth-request-hygiene.md
+++ b/.changeset/fetchwithauth-request-hygiene.md
@@ -1,0 +1,5 @@
+---
+'@seamless-auth/react': patch
+---
+
+Improve request hygiene in the shared auth fetch helper. It no longer sends a JSON `Content-Type` on bodyless requests (some proxies reject a GET that advertises a request content type), and it no longer logs a `console.warn` on every non-ok response. Callers already inspect `response.ok`, and caller-provided headers still take precedence.

--- a/src/fetchWithAuth.ts
+++ b/src/fetchWithAuth.ts
@@ -20,21 +20,19 @@ export const createFetchWithAuth = (opts: FetchWithAuthOptions) => {
 
     const url = `${host}/auth${path}`;
 
+    // Only declare a JSON content type when a body is actually sent. Some
+    // proxies reject a bodyless GET that advertises a request content type.
+    const hasBody = init?.body != null;
+
     const requestInit: RequestInit = {
       ...init,
       credentials: 'include',
       headers: {
-        'Content-Type': 'application/json',
+        ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
         ...init?.headers,
       },
     };
 
-    const response = await fetch(url, requestInit);
-
-    if (!response.ok) {
-      console.warn('Auth fetch failed:', response.status);
-    }
-
-    return response;
+    return fetch(url, requestInit);
   };
 };

--- a/tests/fetchWithAuth.test.tsx
+++ b/tests/fetchWithAuth.test.tsx
@@ -66,4 +66,64 @@ describe('createFetchWithAuth', () => {
 
     await expect(fetchWithAuth('/login')).resolves.toBe(response);
   });
+
+  it('does not set a JSON content type on a bodyless request', async () => {
+    const fetchWithAuth = createFetchWithAuth({
+      authHost: 'https://auth.example.com',
+    });
+
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+
+    await fetchWithAuth('/users/me', { method: 'GET' });
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers['Content-Type']).toBeUndefined();
+  });
+
+  it('sets a JSON content type when a body is present', async () => {
+    const fetchWithAuth = createFetchWithAuth({
+      authHost: 'https://auth.example.com',
+    });
+
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+
+    await fetchWithAuth('/login', {
+      method: 'POST',
+      body: JSON.stringify({ identifier: 'test@example.com' }),
+    });
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('lets caller-provided headers win', async () => {
+    const fetchWithAuth = createFetchWithAuth({
+      authHost: 'https://auth.example.com',
+    });
+
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+
+    await fetchWithAuth('/upload', {
+      method: 'POST',
+      body: 'raw',
+      headers: { 'Content-Type': 'text/plain' },
+    });
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers['Content-Type']).toBe('text/plain');
+  });
+
+  it('does not log a warning when the response is not ok', async () => {
+    const fetchWithAuth = createFetchWithAuth({
+      authHost: 'https://auth.example.com',
+    });
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+
+    await fetchWithAuth('/users/me', { method: 'GET' });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## What

Two request-hygiene fixes in `createFetchWithAuth`:

1. Only set the default `Content-Type: application/json` when the request actually has a body. Bodyless requests (for example GETs) no longer advertise a request content type.
2. Remove the `console.warn('Auth fetch failed:', status)` that fired on every non-ok response.

Caller-provided headers still take precedence, and `credentials: 'include'` is unchanged.

## Why

- Some strict proxies and WAFs reject a bodyless GET that declares a request content type.
- The warn was noisy in production and fired on expected non-ok responses, such as the initial `/users/me` 401 before login. Callers already inspect `response.ok`.

Closes #61.

## Scope note

This changes only the shared helper's default. A few client GET methods still set `Content-Type` explicitly in their own `init.headers`; those are the caller's choice and are left as an optional follow-up so this PR stays focused.

## Tests

Added cases: no content type on a bodyless request, JSON content type when a body is present, caller headers win, and no warn on a non-ok response. `fetchWithAuth.ts` is at 100% coverage.

## Changeset

Patch: request behavior and console output are adopter-observable.

## Checks

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Full suite via pre-commit hook: 171 passed (4 new)
