### PR TITLE
fix(oauth): respect router basename in callback redirect uri

### DIFF
--- a/.changeset/oauth-redirect-basename.md
+++ b/.changeset/oauth-redirect-basename.md
@@ -1,0 +1,5 @@
+---
+'@seamless-auth/react': patch
+---
+
+Fix the bundled OAuth provider buttons so the callback redirect URI respects the router basename. Apps mounted under a non-root basename (for example `/app`) now send `/app/oauth/callback` instead of `/oauth/callback`, which previously failed redirect URI allowlisting or landed on a route that did not exist. Apps mounted at the root are unaffected.

--- a/src/components/OAuthProviderButtons.tsx
+++ b/src/components/OAuthProviderButtons.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { useHref } from 'react-router-dom';
 import { useAuth } from '@/AuthProvider';
 import type { OAuthProvider } from '@/client/createSeamlessAuthClient';
 
@@ -14,6 +15,9 @@ export const OAUTH_PROVIDER_STORAGE_KEY = 'seamless:oauth:provider';
 
 const OAuthProviderButtons: React.FC = () => {
   const { listOAuthProviders, startOAuthLogin } = useAuth();
+  // useHref applies the router basename, so the callback URL stays correct for
+  // apps mounted under a non-root basename (for example /app/oauth/callback).
+  const callbackHref = useHref('/oauth/callback');
   const [providers, setProviders] = useState<OAuthProvider[]>([]);
   const [error, setError] = useState('');
 
@@ -45,7 +49,7 @@ const OAuthProviderButtons: React.FC = () => {
 
       const { authorizationUrl } = await startOAuthLogin({
         providerId,
-        redirectUri: `${window.location.origin}/oauth/callback`,
+        redirectUri: new URL(callbackHref, window.location.origin).toString(),
       });
 
       window.location.assign(authorizationUrl);

--- a/tests/OAuthProviderButtons.test.tsx
+++ b/tests/OAuthProviderButtons.test.tsx
@@ -5,11 +5,19 @@
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import OAuthProviderButtons from '@/components/OAuthProviderButtons';
 
 import { useAuth } from '@/AuthProvider';
 
 jest.mock('@/AuthProvider');
+
+const renderInRouter = (basename?: string) =>
+  render(
+    <MemoryRouter basename={basename} initialEntries={[basename ?? '/']}>
+      <OAuthProviderButtons />
+    </MemoryRouter>
+  );
 
 describe('OAuthProviderButtons', () => {
   const listOAuthProviders = jest.fn();
@@ -24,7 +32,7 @@ describe('OAuthProviderButtons', () => {
   test('renders nothing when no providers are configured', async () => {
     listOAuthProviders.mockResolvedValue({ providers: [] });
 
-    const { container } = render(<OAuthProviderButtons />);
+    const { container } = renderInRouter();
 
     await waitFor(() => expect(listOAuthProviders).toHaveBeenCalled());
     expect(container).toBeEmptyDOMElement();
@@ -36,7 +44,7 @@ describe('OAuthProviderButtons', () => {
     });
     startOAuthLogin.mockResolvedValue({ authorizationUrl: 'http://idp.test/authorize' });
 
-    render(<OAuthProviderButtons />);
+    renderInRouter();
 
     const button = await screen.findByRole('button', { name: /Continue with Mock OIDC/ });
     fireEvent.click(button);
@@ -48,5 +56,24 @@ describe('OAuthProviderButtons', () => {
       })
     );
     expect(window.sessionStorage.getItem('seamless:oauth:provider')).toBe('mock');
+  });
+
+  test('includes the router basename in the callback redirect URI', async () => {
+    listOAuthProviders.mockResolvedValue({
+      providers: [{ id: 'mock', name: 'Mock OIDC', scopes: [] }],
+    });
+    startOAuthLogin.mockResolvedValue({ authorizationUrl: 'http://idp.test/authorize' });
+
+    renderInRouter('/app');
+
+    const button = await screen.findByRole('button', { name: /Continue with Mock OIDC/ });
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(startOAuthLogin).toHaveBeenCalledWith({
+        providerId: 'mock',
+        redirectUri: `${window.location.origin}/app/oauth/callback`,
+      })
+    );
   });
 });

--- a/tests/login.test.tsx
+++ b/tests/login.test.tsx
@@ -24,6 +24,7 @@ jest.mock('@/utils', () => ({
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: jest.fn(),
+  useHref: jest.fn((to: string) => to),
 }));
 
 jest.mock('@/components/phoneInput', () => (props: any) => (


### PR DESCRIPTION
## What

The bundled OAuth provider buttons now build the callback redirect URI with the router basename applied, using `useHref('/oauth/callback')` instead of hardcoding `${window.location.origin}/oauth/callback`.

## Why

An app that mounts its router under a basename (for example `/app`) serves the callback route at `/app/oauth/callback`, but the SDK sent `/oauth/callback`. That mismatch failed redirect URI allowlisting on the server or landed on a route that does not exist, so OAuth login was broken for those apps.

`useHref` resolves an absolute in-router path against the router basename, so the value is correct in both cases and apps mounted at the root are unaffected (it still resolves to `/oauth/callback`).

Closes #62.

## Changes

- `src/components/OAuthProviderButtons.tsx`: derive the callback path with `useHref` and build the absolute URI with `new URL(...)`.
- `tests/OAuthProviderButtons.test.tsx`: render inside `MemoryRouter` (the component now needs router context) and add a basename case asserting `/app/oauth/callback`.
- `tests/login.test.tsx`: add `useHref` to the existing `react-router-dom` mock, since `Login` renders the OAuth buttons.
- Changeset (patch).

## Note

The component now requires router context. In practice it always had it (it renders inside `AuthRoutes` under the app's router), so this is not a usage change for adopters. The README custom-UI example still shows the manual `window.location.origin` form, which is correct for root-mounted apps; documenting the basename case there is a reasonable follow-up.

## Checks

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Full suite: 172 passed (1 new)
