### PR TITLE
fix(webauthn): guard platform authenticator check for server rendering

### DIFF
--- a/.changeset/ssr-safe-platform-authenticator.md
+++ b/.changeset/ssr-safe-platform-authenticator.md
@@ -1,0 +1,5 @@
+---
+'@seamless-auth/react': patch
+---
+
+Make the platform authenticator capability check safe to evaluate in a server environment. `isPlatformAuthenticatorAvailable` previously read `window` without a guard and threw a `ReferenceError` during server-side rendering. It now returns `false` when there is no `window`, matching the guard already used by the WebAuthn availability check.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,6 +47,15 @@ export default [
     },
   },
   {
+    // Jest only reads the `@jest-environment` pragma from the first comment in a
+    // file, so these suites carry it alongside the license text in one block.
+    // The license header is still present, it just is not a byte-for-byte match.
+    files: ['**/*.ssr.test.ts', '**/*.ssr.test.tsx'],
+    rules: {
+      'license-header/header': 'off',
+    },
+  },
+  {
     ignores: ['dist/', 'coverage/', 'node_modules/'],
   },
 ];

--- a/src/client/webauthnSupport.ts
+++ b/src/client/webauthnSupport.ts
@@ -31,6 +31,10 @@ export function isWebAuthnAvailable(): boolean {
  * and similar) can be used on this device.
  */
 export async function isPlatformAuthenticatorAvailable(): Promise<boolean> {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
   if (
     window.PublicKeyCredential &&
     typeof window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable ===

--- a/tests/webauthnSupport.ssr.test.ts
+++ b/tests/webauthnSupport.ssr.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ *
+ * @jest-environment node
+ */
+
+import {
+  isPlatformAuthenticatorAvailable,
+  isWebAuthnAvailable,
+} from '@/client/webauthnSupport';
+
+jest.mock('@simplewebauthn/browser', () => ({
+  browserSupportsWebAuthn: jest.fn(() => true),
+}));
+
+// Runs under the node environment, where `window` genuinely does not exist.
+// jsdom cannot represent this: there the global object is the window and the
+// `window` binding is non-configurable, so it cannot be removed.
+describe('webauthn support in a server environment', () => {
+  it('runs without a window global', () => {
+    expect(typeof window).toBe('undefined');
+  });
+
+  it('reports no platform authenticator without touching window', async () => {
+    await expect(isPlatformAuthenticatorAvailable()).resolves.toBe(false);
+  });
+
+  it('reports WebAuthn unavailable without touching window', () => {
+    expect(isWebAuthnAvailable()).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Guard `isPlatformAuthenticatorAvailable` so it returns `false` instead of throwing when there is no `window`, matching the guard style already used by `isWebAuthnAvailable`.

## Why

The helper read `window.PublicKeyCredential` directly, so evaluating it in a server environment threw `ReferenceError: window is not defined`. It is unreachable today because the only caller invokes it from a `useEffect`, but it is a blocker for Next.js support (#78).

Closes #77.

## Testing note

This needed a real server environment to test. jsdom cannot represent it: there the global object is the window and the `window` binding is non-configurable, so neither `delete global.window` nor `Object.defineProperty` removes it. I confirmed both of those approaches produce a test that passes with the fix reverted, meaning they verify nothing.

The regression test therefore lives in `tests/webauthnSupport.ssr.test.ts` under the node environment. Verified it genuinely catches the bug:

- with the fix: 3 passed
- with the fix reverted: fails with `Rejected to value: [ReferenceError: window is not defined]`

It also asserts `typeof window === 'undefined'` up front, so if the environment pragma ever stops being honored the suite fails loudly rather than silently passing under jsdom.

## Lint config change

Jest only reads the `@jest-environment` pragma from the first comment block in a file, which collides with the exact-match `license-header/header` rule. I confirmed a pragma in a second block is silently ignored by Jest. The file therefore carries the pragma alongside the license text in one block, and `eslint.config.mjs` turns off `license-header/header` for `*.ssr.test.ts` only. The license header is still present, it just is not a byte-for-byte match.

## Checks

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Full suite: 175 passed (3 new), `webauthnSupport.ts` at 100% coverage
- Changeset (patch)
