### PR TITLE
chore: enforce framework-agnostic boundary in the client layer

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,6 +56,53 @@ export default [
     },
   },
   {
+    // The client layer stays framework agnostic so it can be extracted into a
+    // shared package for non-React adapters. See #64.
+    files: [
+      'src/client/**/*.ts',
+      'src/fetchWithAuth.ts',
+      'src/scopedRoles.ts',
+      'src/types.ts',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                'react',
+                'react/*',
+                'react-dom',
+                'react-dom/*',
+                'react-router',
+                'react-router-dom',
+              ],
+              message:
+                'The client layer must stay framework agnostic. Keep React and router imports in the binding layer. See #64.',
+            },
+            {
+              group: [
+                '@/AuthProvider',
+                '@/AuthRoutes',
+                '@/hooks/*',
+                '@/views/*',
+                '@/components/*',
+                '**/AuthProvider',
+                '**/AuthRoutes',
+                '**/hooks/*',
+                '**/views/*',
+                '**/components/*',
+              ],
+              message:
+                'The client layer must not import from the React binding layer. See #64.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     ignores: ['dist/', 'coverage/', 'node_modules/'],
   },
 ];


### PR DESCRIPTION
## What

Add an ESLint boundary rule so the framework-agnostic client layer cannot import React, the router, or anything from the React binding layer.

Covered paths: `src/client/**`, `src/fetchWithAuth.ts`, `src/scopedRoles.ts`, `src/types.ts`.

Blocked imports: `react`, `react-dom`, `react-router`, `react-router-dom`, and `AuthProvider`, `AuthRoutes`, `hooks/*`, `views/*`, `components/*` in both alias (`@/...`) and relative (`../...`) form.

Closes #76.

## Why

That layer already has zero React imports, but nothing enforced it. One casual import would silently make it non-extractable, and the coupling would be found late. This encodes the existing state so a future extraction (#64) is a mechanical move rather than an untangling job.

## Implementation note

Used core ESLint `no-restricted-imports` rather than `import/no-restricted-paths`. `eslint-plugin-import` is a dev dependency but is not registered in the flat config, and its path-based zones would not resolve the `@/` alias without adding a resolver. `no-restricted-imports` matches the specifier as written, so it catches both alias and relative forms with no new dependency.

## Verification

Confirmed the rule actually fires rather than merely existing:

- Baseline: `npm run lint` clean, so the rule encodes current reality and required no code changes.
- Injected `react`, `react-router-dom`, `@/AuthProvider`, and `@/hooks/*` imports into a client module: all four reported as errors.
- Injected the relative forms `../AuthProvider` and `../hooks/useAuthClient`: both reported as errors.
- Restored: clean again.

The React layer is unaffected and still imports React normally.

## Checks

- `npm run lint`, `npm run typecheck`, `npm run format:check` clean
- Full suite via pre-commit hook: 175 passed
- No changeset: lint configuration only, no adopter-facing change
