### PR TITLE
fix(utils): detect chromium derivatives in parseUserAgent

### DIFF
--- a/.changeset/parse-user-agent-browsers.md
+++ b/.changeset/parse-user-agent-browsers.md
@@ -1,0 +1,7 @@
+---
+'@seamless-auth/react': patch
+---
+
+Improve browser detection used for passkey device labels. Opera, Vivaldi, Samsung Internet, and Brave are now identified instead of being reported as Chrome, and Chrome and Firefox on iOS are recognized through their `CriOS` and `FxiOS` tokens. Chromium derivatives are now matched before the generic chrome token, so the result no longer depends on check ordering.
+
+Brave is detected through `navigator.brave` because it ships a user agent identical to Chrome's. Arc exposes no distinguishing marker and is still reported as chrome.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,6 +75,8 @@ export async function isPasskeySupported(): Promise<boolean> {
   return isPlatformAuthenticatorAvailable();
 }
 
+type NavigatorWithBrave = Navigator & { brave?: unknown };
+
 export function parseUserAgent() {
   const ua = navigator.userAgent.toLowerCase();
 
@@ -87,10 +89,18 @@ export function parseUserAgent() {
   else if (/windows/.test(ua)) platform = 'windows';
   else if (/linux/.test(ua)) platform = 'linux';
 
-  if (/chrome/.test(ua)) browser = 'chrome';
-  if (/safari/.test(ua) && !/chrome/.test(ua)) browser = 'safari';
-  if (/firefox/.test(ua)) browser = 'firefox';
-  if (/edg/.test(ua)) browser = 'edge';
+  // Order matters: every Chromium derivative also carries a chrome token, so the
+  // specific ones have to be tested first. Brave is only detectable through
+  // navigator.brave because it ships a user agent identical to Chrome's. Arc
+  // exposes no marker at all and is reported as chrome.
+  if ((navigator as NavigatorWithBrave).brave) browser = 'brave';
+  else if (/edg\/|edgios/.test(ua)) browser = 'edge';
+  else if (/opr\/|opt\/|opera/.test(ua)) browser = 'opera';
+  else if (/vivaldi/.test(ua)) browser = 'vivaldi';
+  else if (/samsungbrowser/.test(ua)) browser = 'samsung';
+  else if (/firefox|fxios/.test(ua)) browser = 'firefox';
+  else if (/chrome|crios/.test(ua)) browser = 'chrome';
+  else if (/safari/.test(ua)) browser = 'safari';
 
   const deviceInfo = `${platform} • ${browser}`;
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -184,4 +184,68 @@ describe('parseUserAgent', () => {
     expect(result.platform).toBe('unknown');
     expect(result.browser).toBe('unknown');
   });
+
+  it('detects Opera ahead of the chrome token', () => {
+    setUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0 Safari/537.36 OPR/106.0'
+    );
+
+    const result = parseUserAgent();
+
+    expect(result.platform).toBe('windows');
+    expect(result.browser).toBe('opera');
+  });
+
+  it('detects Vivaldi ahead of the chrome token', () => {
+    setUserAgent(
+      'Mozilla/5.0 (Mac OS X 13_0) AppleWebKit/537.36 Chrome/120.0 Safari/537.36 Vivaldi/6.5'
+    );
+
+    expect(parseUserAgent().browser).toBe('vivaldi');
+  });
+
+  it('detects Samsung Internet ahead of the chrome token', () => {
+    setUserAgent(
+      'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 SamsungBrowser/23.0 Chrome/115.0 Mobile Safari/537.36'
+    );
+
+    expect(parseUserAgent().browser).toBe('samsung');
+  });
+
+  it('detects Chrome on iOS via the CriOS token', () => {
+    setUserAgent(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 CriOS/120.0 Mobile/15E148 Safari/604.1'
+    );
+
+    const result = parseUserAgent();
+
+    expect(result.platform).toBe('ios');
+    expect(result.browser).toBe('chrome');
+  });
+
+  it('detects Brave through navigator.brave, since its user agent matches Chrome', () => {
+    setUserAgent(
+      'Mozilla/5.0 (Mac OS X 13_0) AppleWebKit/537.36 Chrome/120.0 Safari/537.36'
+    );
+    Object.defineProperty(window.navigator, 'brave', {
+      value: {},
+      configurable: true,
+    });
+
+    try {
+      expect(parseUserAgent().browser).toBe('brave');
+    } finally {
+      delete (window.navigator as Navigator & { brave?: unknown }).brave;
+    }
+  });
+
+  it('reports Arc as chrome, which is the documented limitation', () => {
+    // Arc ships a Chrome user agent with no distinguishing token, so it cannot
+    // be told apart from Chrome. This test pins the known behavior.
+    setUserAgent(
+      'Mozilla/5.0 (Mac OS X 14_0) AppleWebKit/537.36 Chrome/120.0 Safari/537.36'
+    );
+
+    expect(parseUserAgent().browser).toBe('chrome');
+  });
 });


### PR DESCRIPTION
## What

Improve `parseUserAgent` browser detection, which feeds the friendly device label stored as passkey credential metadata.

- Detect Opera (`OPR/`, `OPT/`), Vivaldi, and Samsung Internet instead of reporting them as chrome
- Detect Brave through `navigator.brave`
- Recognize Chrome and Firefox on iOS through their `CriOS` and `FxiOS` tokens
- Match Chromium derivatives before the generic chrome token, so the result no longer depends on check ordering

Closes #60.

## Why the previous logic was wrong

The old checks were a sequence of independent `if` statements where the last match won, so the outcome depended on ordering rather than specificity. Every Chromium derivative also carries a `chrome` token, so Opera, Vivaldi, and Samsung Internet all reported as chrome.

## Two honest limitations

- **Brave** ships a user agent byte-identical to Chrome's, deliberately. It cannot be detected from the UA string at all, so it is detected through the `navigator.brave` object instead.
- **Arc** exposes no distinguishing token and no marker object, so it genuinely cannot be told apart from Chrome. It still reports as chrome. There is a test pinning this so the limitation is recorded rather than assumed fixed.

The issue suggested User-Agent Client Hints as an option. I did not use them here: `navigator.userAgentData.brands` does not expose Brave or Arc either, Firefox and Safari do not implement it at all, so the UA fallback would still be required, and richer platform data needs the async `getHighEntropyValues`. For a cosmetic device label, a sync ordered match plus the Brave object check covers everything actually detectable at lower complexity.

## Tests

Six new cases (Opera, Vivaldi, Samsung Internet, Chrome on iOS, Brave, and the Arc limitation). All five pre-existing cases still pass unchanged, so there is no regression in the previously supported browsers. `utils.ts` is at 100% coverage.

## Checks

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Full suite: 181 passed (6 new)
- Changeset (patch): the stored `browser` and `deviceInfo` metadata values change for the newly detected browsers
