### PR TITLE
fix(oauth): surface server error detail from finishOAuthLogin

### DIFF
--- a/.changeset/oauth-error-detail.md
+++ b/.changeset/oauth-error-detail.md
@@ -1,0 +1,9 @@
+---
+'@seamless-auth/react': minor
+---
+
+Surface the auth server's error detail when an OAuth callback fails. `finishOAuthLogin()` previously discarded the response body and threw a generic `Error('Failed to finish OAuth login')`, so consuming apps could not tell users what went wrong.
+
+It now throws a `SeamlessAuthError` carrying the server message, the HTTP `status`, and the parsed `body`. `SeamlessAuthError` is exported so callers can narrow with `instanceof` and map known failures to their own messaging. A body that is empty or not JSON is handled gracefully and falls back to the previous generic message.
+
+Callers matching on the exact string `'Failed to finish OAuth login'` should switch to inspecting `status` or `body`.

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -14,6 +14,7 @@ import {
   StepUpStatus,
   StepUpVerificationResult,
 } from '@/client/createSeamlessAuthClient';
+import { toSeamlessAuthError } from '@/client/errors';
 import { PasskeyPrfInput } from '@/client/webauthnPrf';
 import { Credential, Organization, User } from '@/types';
 import React, {
@@ -258,7 +259,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     const response = await authClient.finishOAuthLogin(input);
 
     if (!response.ok) {
-      throw new Error('Failed to finish OAuth login');
+      throw await toSeamlessAuthError(response, 'Failed to finish OAuth login');
     }
 
     await validateToken();

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ */
+
+/**
+ * Error carrying the auth server's response detail, so callers can map known
+ * failures to their own messaging instead of only seeing a generic string.
+ */
+export class SeamlessAuthError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body?: unknown) {
+    super(message);
+    this.name = 'SeamlessAuthError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+function extractMessage(body: unknown): string | undefined {
+  if (typeof body !== 'object' || body === null) {
+    return undefined;
+  }
+
+  // The auth API reports failures as `{ error: string }`. `message` is accepted
+  // too so a differently shaped payload still produces a useful message.
+  const { error, message } = body as { error?: unknown; message?: unknown };
+
+  if (typeof error === 'string' && error) {
+    return error;
+  }
+
+  return typeof message === 'string' && message ? message : undefined;
+}
+
+/**
+ * Build a `SeamlessAuthError` from a failed response, preserving the status and
+ * the parsed body. The body may be empty or non-JSON, which is not treated as a
+ * failure: the fallback message is used instead.
+ */
+export async function toSeamlessAuthError(
+  response: Response,
+  fallbackMessage: string
+): Promise<SeamlessAuthError> {
+  let body: unknown;
+
+  try {
+    body = await response.json();
+  } catch {
+    body = undefined;
+  }
+
+  return new SeamlessAuthError(
+    extractMessage(body) ?? fallbackMessage,
+    response.status,
+    body
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import {
   TotpStatus,
   UpdateOrganizationInput,
 } from '@/client/createSeamlessAuthClient';
+import { SeamlessAuthError } from '@/client/errors';
 import {
   encodePrfSalt,
   extractPasskeyPrfResult,
@@ -60,6 +61,7 @@ export {
   hasScopedRole,
   isPasskeyPrfSupported,
   roleGrantsAccess,
+  SeamlessAuthError,
   useAuth,
   useAuthClient,
   usePasskeySupport,

--- a/tests/authProvider.test.tsx
+++ b/tests/authProvider.test.tsx
@@ -363,4 +363,70 @@ describe('AuthProvider', () => {
       mockFetchWithAuthImpl.mock.calls.filter(([path]) => path === 'users/me')
     ).toHaveLength(1);
   });
+
+  describe('finishOAuthLogin failures', () => {
+    const renderAndCaptureAuth = async () => {
+      let auth: ReturnType<typeof useAuth> | null = null;
+
+      const Capture = () => {
+        auth = useAuth();
+        return null;
+      };
+
+      mockFetchWithAuthImpl.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          user: { id: '1', email: 'test@example.com', phone: '', roles: [] },
+          credentials: [],
+        }),
+      } as any);
+
+      await act(async () => {
+        render(
+          <AuthProvider apiHost={apiHost}>
+            <Capture />
+          </AuthProvider>
+        );
+      });
+
+      return auth as unknown as ReturnType<typeof useAuth>;
+    };
+
+    const input = { providerId: 'github', code: 'code', state: 'state' };
+
+    it('surfaces the auth server error detail instead of a generic message', async () => {
+      const auth = await renderAndCaptureAuth();
+
+      mockFetchWithAuthImpl.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: 'OAuth signup is disabled' }),
+      } as any);
+
+      await expect(auth.finishOAuthLogin(input)).rejects.toMatchObject({
+        name: 'SeamlessAuthError',
+        message: 'OAuth signup is disabled',
+        status: 403,
+        body: { error: 'OAuth signup is disabled' },
+      });
+    });
+
+    it('falls back to a generic message when the body is not JSON', async () => {
+      const auth = await renderAndCaptureAuth();
+
+      mockFetchWithAuthImpl.mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: async () => {
+          throw new SyntaxError('Unexpected token');
+        },
+      } as any);
+
+      await expect(auth.finishOAuthLogin(input)).rejects.toMatchObject({
+        name: 'SeamlessAuthError',
+        message: 'Failed to finish OAuth login',
+        status: 502,
+      });
+    });
+  });
 });

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ */
+
+import { SeamlessAuthError, toSeamlessAuthError } from '@/client/errors';
+
+const responseWith = (status: number, json: () => Promise<unknown>) =>
+  ({ status, json }) as unknown as Response;
+
+describe('toSeamlessAuthError', () => {
+  it('uses the auth API error field as the message', async () => {
+    const error = await toSeamlessAuthError(
+      responseWith(403, async () => ({ error: 'OAuth signup is disabled' })),
+      'fallback'
+    );
+
+    expect(error).toBeInstanceOf(SeamlessAuthError);
+    expect(error.message).toBe('OAuth signup is disabled');
+    expect(error.status).toBe(403);
+    expect(error.body).toEqual({ error: 'OAuth signup is disabled' });
+  });
+
+  it('falls back to the message field when error is absent', async () => {
+    const error = await toSeamlessAuthError(
+      responseWith(400, async () => ({ message: 'Something specific' })),
+      'fallback'
+    );
+
+    expect(error.message).toBe('Something specific');
+  });
+
+  it('uses the fallback when the body is not JSON', async () => {
+    const error = await toSeamlessAuthError(
+      responseWith(500, async () => {
+        throw new SyntaxError('Unexpected token');
+      }),
+      'Failed to finish OAuth login'
+    );
+
+    expect(error.message).toBe('Failed to finish OAuth login');
+    expect(error.status).toBe(500);
+    expect(error.body).toBeUndefined();
+  });
+
+  it('uses the fallback when the body carries no usable message', async () => {
+    const error = await toSeamlessAuthError(
+      responseWith(400, async () => ({ error: '' })),
+      'fallback'
+    );
+
+    expect(error.message).toBe('fallback');
+    expect(error.body).toEqual({ error: '' });
+  });
+
+  it('is catchable as an Error and keeps its name', async () => {
+    const error = await toSeamlessAuthError(
+      responseWith(400, async () => ({ error: 'nope' })),
+      'fallback'
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('SeamlessAuthError');
+  });
+});


### PR DESCRIPTION
## What

`finishOAuthLogin()` now throws a `SeamlessAuthError` carrying the auth server's message, HTTP `status`, and parsed `body`, instead of discarding the response and throwing a generic `Error('Failed to finish OAuth login')`.

`SeamlessAuthError` is exported from `src/index.ts` so callers can narrow with `instanceof` and read `status` and `body`.

Closes #51.

## Important: this does not fully deliver the issue's motivating case

The issue's motivation is the "provider did not return an email address" failure. That specific reason is **not currently exposed by the API**, so this change alone will not make it actionable.

In `seamless-auth-api`, the OAuth callback's `catch` block logs the reason server-side (`metadata: { reason: 'callback_failed' }`) and responds with a generic `{ error: 'OAuth login failed' }`. There is no distinct payload or code for the missing-email case, so that is the most detail the SDK can surface today.

What this PR does deliver: every reason the API *does* distinguish now reaches the caller, for example `OAuth signup is disabled` (403), `Invalid OAuth state` (400), and `OAuth provider not found` (404).

Making the missing-email case actionable needs a follow-up in `seamless-auth-api` to return a distinct error (ideally with a stable machine-readable code). Worth filing there.

## Correction to the issue's proposed fix

The description proposes reading `res.error?.message` and `res.error?.code` from the server-side `@seamless-auth/core` result shape. Two mismatches with this repo:

- The React client returns a raw `Response`, not `{ ok, error, status }`, so the body has to be read explicitly and defensively (it may be empty or non-JSON).
- The API reports failures as `{ error: string }`. There is no `message` field and no `code` field, so a `code` cannot be populated yet. `message` is still accepted as a fallback shape in case other endpoints differ.

## Relationship to #24

This defines an error convention, which is #24's job. I kept the surface deliberately small (one error class, no result-object refactor) so #24 can supersede or extend it without a second migration. Noted on both issues.

## Tests

- `tests/errors.test.ts`: message extraction from `error`, fallback to `message`, fallback when the body is not JSON, fallback on an empty message, and `instanceof Error` with a stable `name`.
- `tests/authProvider.test.tsx`: provider-level cases asserting the server detail reaches the caller and that a non-JSON body falls back cleanly.

Confirmed the provider tests actually catch the regression: with the fix reverted they fail with the old `[Error: Failed to finish OAuth login]`.

`errors.ts` is at 100% coverage.

## Checks

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Full suite: 188 passed (7 new)
- Changeset (minor): new public export, and the thrown error message changes for callers matching on the old string
