### PR TITLE
refactor(routes): rename auth routes to kebab-case

### DIFF
--- a/.changeset/canonical-auth-route-names.md
+++ b/.changeset/canonical-auth-route-names.md
@@ -1,0 +1,9 @@
+---
+'@seamless-auth/react': minor
+---
+
+Normalize the bundled `AuthRoutes` paths to a consistent kebab-case set: `/passkey-login`, `/verify-phone-otp`, `/verify-email-otp`, `/verify-magic-link`, `/register-passkey`, and `/magic-link-sent`. `/login` and `/oauth/callback` are unchanged.
+
+Every previous path still resolves. Each redirects to its canonical path and preserves query string, hash, and router state, so existing bookmarks and in-flight magic-link emails keep working. `/verify-magiclink` in particular is kept as a standing alias because the auth API builds that URL when sending magic-link emails.
+
+Apps that link directly to the built-in screens should move to the canonical paths. Apps that only render `AuthRoutes` need no change.

--- a/.changeset/canonical-auth-route-names.md
+++ b/.changeset/canonical-auth-route-names.md
@@ -2,8 +2,16 @@
 '@seamless-auth/react': minor
 ---
 
-Normalize the bundled `AuthRoutes` paths to a consistent kebab-case set: `/passkey-login`, `/verify-phone-otp`, `/verify-email-otp`, `/verify-magic-link`, `/register-passkey`, and `/magic-link-sent`. `/login` and `/oauth/callback` are unchanged.
+Rename the bundled `AuthRoutes` paths to a consistent kebab-case set. The previous mixed-case paths are no longer served.
 
-Every previous path still resolves. Each redirects to its canonical path and preserves query string, hash, and router state, so existing bookmarks and in-flight magic-link emails keep working. `/verify-magiclink` in particular is kept as a standing alias because the auth API builds that URL when sending magic-link emails.
+| Old path           | New path            |
+| ------------------ | ------------------- |
+| `/passKeyLogin`    | `/passkey-login`    |
+| `/verifyPhoneOTP`  | `/verify-phone-otp` |
+| `/verifyEmailOTP`  | `/verify-email-otp` |
+| `/registerPasskey` | `/register-passkey` |
+| `/magiclinks-sent` | `/magic-link-sent`  |
 
-Apps that link directly to the built-in screens should move to the canonical paths. Apps that only render `AuthRoutes` need no change.
+BREAKING: anything linking directly to an old path now falls through to `/login`. Apps that only render `AuthRoutes` and rely on its internal navigation need no change.
+
+`/login`, `/verify-magiclink`, and `/oauth/callback` are unchanged. The latter two are fixed by contracts outside this package: the auth API builds the magic-link URL when it sends the email, and the OAuth callback is registered with providers as an allowed redirect URI.

--- a/README.md
+++ b/README.md
@@ -501,25 +501,26 @@ function CustomLogin() {
 
 These are optional UI wrappers over the same SDK primitives the package now exports for custom flows.
 
-### Legacy route names
+### Renamed routes
 
-The earlier mixed-case paths still resolve. Each one redirects to its canonical path, preserving
-query string, hash, and router state, so existing bookmarks and in-flight links keep working:
+The earlier mixed-case paths were renamed and are no longer served. Anything linking directly to
+them now falls through to `/login`, so update those links:
 
-| Legacy path         | Canonical path       |
-| ------------------- | -------------------- |
-| `/passKeyLogin`     | `/passkey-login`     |
-| `/verifyPhoneOTP`   | `/verify-phone-otp`  |
-| `/verifyEmailOTP`   | `/verify-email-otp`  |
-| `/verify-magiclink` | `/verify-magic-link` |
-| `/registerPasskey`  | `/register-passkey`  |
-| `/magiclinks-sent`  | `/magic-link-sent`   |
+| Old path           | New path            |
+| ------------------ | ------------------- |
+| `/passKeyLogin`    | `/passkey-login`    |
+| `/verifyPhoneOTP`  | `/verify-phone-otp` |
+| `/verifyEmailOTP`  | `/verify-email-otp` |
+| `/registerPasskey` | `/register-passkey` |
+| `/magiclinks-sent` | `/magic-link-sent`  |
 
-`/verify-magiclink` is a standing contract rather than a temporary alias. The auth API builds that
-URL when it sends a magic-link email, so it keeps resolving regardless of migration state.
+Two paths are unchanged because they are owned by contracts outside this package:
 
-`/oauth/callback` is unchanged. It is registered with OAuth providers as an allowed redirect URI, so
-renaming it would break configured integrations.
+- `/verify-magiclink` is the URL the auth API builds when it emails a magic link, so it has to match
+  that value exactly. Renaming it here would send every emailed link to `/login` with the token
+  discarded.
+- `/oauth/callback` is registered with OAuth providers as an allowed redirect URI, so renaming it
+  would break configured integrations.
 
 ## Backend Expectations
 

--- a/README.md
+++ b/README.md
@@ -488,18 +488,38 @@ function CustomLogin() {
 
 ## Built-In Routes
 
-`AuthRoutes` currently includes:
+`AuthRoutes` serves these canonical paths:
 
 - `/login`
-- `/passKeyLogin`
-- `/verifyPhoneOTP`
-- `/verifyEmailOTP`
-- `/verify-magiclink`
+- `/passkey-login`
+- `/verify-phone-otp`
+- `/verify-email-otp`
+- `/verify-magic-link`
 - `/oauth/callback`
-- `/registerPasskey`
-- `/magiclinks-sent`
+- `/register-passkey`
+- `/magic-link-sent`
 
 These are optional UI wrappers over the same SDK primitives the package now exports for custom flows.
+
+### Legacy route names
+
+The earlier mixed-case paths still resolve. Each one redirects to its canonical path, preserving
+query string, hash, and router state, so existing bookmarks and in-flight links keep working:
+
+| Legacy path         | Canonical path       |
+| ------------------- | -------------------- |
+| `/passKeyLogin`     | `/passkey-login`     |
+| `/verifyPhoneOTP`   | `/verify-phone-otp`  |
+| `/verifyEmailOTP`   | `/verify-email-otp`  |
+| `/verify-magiclink` | `/verify-magic-link` |
+| `/registerPasskey`  | `/register-passkey`  |
+| `/magiclinks-sent`  | `/magic-link-sent`   |
+
+`/verify-magiclink` is a standing contract rather than a temporary alias. The auth API builds that
+URL when it sends a magic-link email, so it keeps resolving regardless of migration state.
+
+`/oauth/callback` is unchanged. It is registered with OAuth providers as an allowed redirect URI, so
+renaming it would break configured integrations.
 
 ## Backend Expectations
 

--- a/src/AuthRoutes.tsx
+++ b/src/AuthRoutes.tsx
@@ -4,7 +4,7 @@
  * See LICENSE file in the project root for full license information
  */
 
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
 import Login from '@/views/Login';
 import PassKeyLogin from '@/views/PassKeyLogin';
@@ -14,17 +14,40 @@ import EmailRegistration from '@/views/EmailRegistration';
 import VerifyMagicLink from '@/views/VerifyMagicLink';
 import OAuthCallback from '@/views/OAuthCallback';
 import MagicLinkSent from './components/MagicLinkSent';
+import { authRoutePaths, legacyAuthRouteAliases } from './routes';
+
+/**
+ * Forwards a superseded path to its canonical one. Search, hash, and router
+ * state are carried over because these screens depend on them, for example the
+ * magic-link token in `?token=` and the identifier passed to the sent screen.
+ */
+const LegacyRouteRedirect = ({ to }: { to: string }) => {
+  const location = useLocation();
+
+  return (
+    <Navigate
+      to={{ pathname: to, search: location.search, hash: location.hash }}
+      state={location.state}
+      replace
+    />
+  );
+};
 
 export const AuthRoutes = () => (
   <Routes>
-    <Route path="/login" element={<Login />} />
-    <Route path="/passKeyLogin" element={<PassKeyLogin />} />
-    <Route path="/verifyPhoneOTP" element={<PhoneRegistration />} />
-    <Route path="/verifyEmailOTP" element={<EmailRegistration />} />
-    <Route path="/verify-magiclink" element={<VerifyMagicLink />} />
-    <Route path="/oauth/callback" element={<OAuthCallback />} />
-    <Route path="/registerPasskey" element={<PasskeyRegistration />} />
-    <Route path="/magiclinks-sent" element={<MagicLinkSent />} />
-    <Route path="*" element={<Navigate to="/login" replace />} />
+    <Route path={authRoutePaths.login} element={<Login />} />
+    <Route path={authRoutePaths.passkeyLogin} element={<PassKeyLogin />} />
+    <Route path={authRoutePaths.verifyPhoneOtp} element={<PhoneRegistration />} />
+    <Route path={authRoutePaths.verifyEmailOtp} element={<EmailRegistration />} />
+    <Route path={authRoutePaths.verifyMagicLink} element={<VerifyMagicLink />} />
+    <Route path={authRoutePaths.oauthCallback} element={<OAuthCallback />} />
+    <Route path={authRoutePaths.registerPasskey} element={<PasskeyRegistration />} />
+    <Route path={authRoutePaths.magicLinkSent} element={<MagicLinkSent />} />
+
+    {legacyAuthRouteAliases.map(({ from, to }) => (
+      <Route key={from} path={from} element={<LegacyRouteRedirect to={to} />} />
+    ))}
+
+    <Route path="*" element={<Navigate to={authRoutePaths.login} replace />} />
   </Routes>
 );

--- a/src/AuthRoutes.tsx
+++ b/src/AuthRoutes.tsx
@@ -4,7 +4,7 @@
  * See LICENSE file in the project root for full license information
  */
 
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 
 import Login from '@/views/Login';
 import PassKeyLogin from '@/views/PassKeyLogin';
@@ -14,24 +14,7 @@ import EmailRegistration from '@/views/EmailRegistration';
 import VerifyMagicLink from '@/views/VerifyMagicLink';
 import OAuthCallback from '@/views/OAuthCallback';
 import MagicLinkSent from './components/MagicLinkSent';
-import { authRoutePaths, legacyAuthRouteAliases } from './routes';
-
-/**
- * Forwards a superseded path to its canonical one. Search, hash, and router
- * state are carried over because these screens depend on them, for example the
- * magic-link token in `?token=` and the identifier passed to the sent screen.
- */
-const LegacyRouteRedirect = ({ to }: { to: string }) => {
-  const location = useLocation();
-
-  return (
-    <Navigate
-      to={{ pathname: to, search: location.search, hash: location.hash }}
-      state={location.state}
-      replace
-    />
-  );
-};
+import { authRoutePaths } from './routes';
 
 export const AuthRoutes = () => (
   <Routes>
@@ -43,11 +26,6 @@ export const AuthRoutes = () => (
     <Route path={authRoutePaths.oauthCallback} element={<OAuthCallback />} />
     <Route path={authRoutePaths.registerPasskey} element={<PasskeyRegistration />} />
     <Route path={authRoutePaths.magicLinkSent} element={<MagicLinkSent />} />
-
-    {legacyAuthRouteAliases.map(({ from, to }) => (
-      <Route key={from} path={from} element={<LegacyRouteRedirect to={to} />} />
-    ))}
-
     <Route path="*" element={<Navigate to={authRoutePaths.login} replace />} />
   </Routes>
 );

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ */
+
+/**
+ * Canonical paths for the bundled auth screens. Kebab-case throughout so the
+ * built-in route surface is predictable to type, document, and link to.
+ */
+export const authRoutePaths = {
+  login: '/login',
+  passkeyLogin: '/passkey-login',
+  verifyPhoneOtp: '/verify-phone-otp',
+  verifyEmailOtp: '/verify-email-otp',
+  verifyMagicLink: '/verify-magic-link',
+  oauthCallback: '/oauth/callback',
+  registerPasskey: '/register-passkey',
+  magicLinkSent: '/magic-link-sent',
+} as const;
+
+/**
+ * Superseded paths, kept working so existing bookmarks and in-flight links do
+ * not break.
+ *
+ * `/verify-magiclink` is a standing contract rather than a migration aid: the
+ * auth API builds that URL when it sends a magic-link email, so it has to keep
+ * resolving even after adopters move to the canonical paths.
+ */
+export const legacyAuthRouteAliases: ReadonlyArray<{ from: string; to: string }> = [
+  { from: '/passKeyLogin', to: authRoutePaths.passkeyLogin },
+  { from: '/verifyPhoneOTP', to: authRoutePaths.verifyPhoneOtp },
+  { from: '/verifyEmailOTP', to: authRoutePaths.verifyEmailOtp },
+  { from: '/verify-magiclink', to: authRoutePaths.verifyMagicLink },
+  { from: '/registerPasskey', to: authRoutePaths.registerPasskey },
+  { from: '/magiclinks-sent', to: authRoutePaths.magicLinkSent },
+];

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -5,33 +5,23 @@
  */
 
 /**
- * Canonical paths for the bundled auth screens. Kebab-case throughout so the
- * built-in route surface is predictable to type, document, and link to.
+ * Paths for the bundled auth screens.
+ *
+ * Kebab-case throughout, except for two paths that are dictated by contracts
+ * outside this package rather than by the naming convention:
+ *
+ * - `verifyMagicLink` is the URL the auth API builds when it emails a magic
+ *   link, so it has to match that value exactly.
+ * - `oauthCallback` is registered with OAuth providers as an allowed redirect
+ *   URI, so renaming it would break configured integrations.
  */
 export const authRoutePaths = {
   login: '/login',
   passkeyLogin: '/passkey-login',
   verifyPhoneOtp: '/verify-phone-otp',
   verifyEmailOtp: '/verify-email-otp',
-  verifyMagicLink: '/verify-magic-link',
+  verifyMagicLink: '/verify-magiclink',
   oauthCallback: '/oauth/callback',
   registerPasskey: '/register-passkey',
   magicLinkSent: '/magic-link-sent',
 } as const;
-
-/**
- * Superseded paths, kept working so existing bookmarks and in-flight links do
- * not break.
- *
- * `/verify-magiclink` is a standing contract rather than a migration aid: the
- * auth API builds that URL when it sends a magic-link email, so it has to keep
- * resolving even after adopters move to the canonical paths.
- */
-export const legacyAuthRouteAliases: ReadonlyArray<{ from: string; to: string }> = [
-  { from: '/passKeyLogin', to: authRoutePaths.passkeyLogin },
-  { from: '/verifyPhoneOTP', to: authRoutePaths.verifyPhoneOtp },
-  { from: '/verifyEmailOTP', to: authRoutePaths.verifyEmailOtp },
-  { from: '/verify-magiclink', to: authRoutePaths.verifyMagicLink },
-  { from: '/registerPasskey', to: authRoutePaths.registerPasskey },
-  { from: '/magiclinks-sent', to: authRoutePaths.magicLinkSent },
-];

--- a/src/views/EmailRegistration.tsx
+++ b/src/views/EmailRegistration.tsx
@@ -10,6 +10,7 @@ import { useAuthClient } from '@/hooks/useAuthClient';
 import { usePasskeySupport } from '@/hooks/usePasskeySupport';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { authRoutePaths } from '@/routes';
 import styles from '@/styles/verifyOTP.module.css';
 import OtpInput from '@/components/OtpInput';
 
@@ -73,7 +74,7 @@ const EmailRegistration: React.FC = () => {
       }
 
       if (passkeySupported) {
-        navigate('/registerPasskey');
+        navigate(authRoutePaths.registerPasskey);
       } else {
         await refreshSession();
         navigate('/');

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -10,6 +10,7 @@ import React, { useEffect, useState } from 'react';
 import { useAuthClient } from '@/hooks/useAuthClient';
 import { usePasskeySupport } from '@/hooks/usePasskeySupport';
 import { useNavigate } from 'react-router-dom';
+import { authRoutePaths } from '@/routes';
 import styles from '@/styles/login.module.css';
 import { isValidEmail, isValidPhoneNumber } from '../utils';
 import AuthFallbackOptions from '@/components/AuthFallbackOptions';
@@ -100,7 +101,7 @@ const Login: React.FC = () => {
       const data = await response.json();
 
       if (data.message === 'Success') {
-        navigate('/verifyEmailOTP');
+        navigate(authRoutePaths.verifyEmailOtp);
         return;
       }
       setFormErrors(
@@ -123,7 +124,7 @@ const Login: React.FC = () => {
         return;
       }
 
-      navigate('/magiclinks-sent', { state: { identifier } });
+      navigate(authRoutePaths.magicLinkSent, { state: { identifier } });
     } catch {
       console.error('Failed to send magic link.');
       setFormErrors('Failed to send magic link.');
@@ -139,7 +140,7 @@ const Login: React.FC = () => {
         return;
       }
 
-      navigate('/verifyPhoneOTP', { state: { flow: 'login' } });
+      navigate(authRoutePaths.verifyPhoneOtp, { state: { flow: 'login' } });
     } catch {
       console.error('Failed to send phone OTP.');
       setFormErrors('Failed to send OTP.');
@@ -155,7 +156,7 @@ const Login: React.FC = () => {
         return;
       }
 
-      navigate('/verifyEmailOTP', { state: { flow: 'login' } });
+      navigate(authRoutePaths.verifyEmailOtp, { state: { flow: 'login' } });
     } catch {
       console.error('Failed to send email OTP.');
       setFormErrors('Failed to send email code.');

--- a/src/views/PhoneRegistration.tsx
+++ b/src/views/PhoneRegistration.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '@/AuthProvider';
 import { useAuthClient } from '@/hooks/useAuthClient';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { authRoutePaths } from '@/routes';
 import styles from '@/styles/verifyOTP.module.css';
 import OtpInput from '@/components/OtpInput';
 
@@ -128,7 +129,7 @@ const PhoneRegistration: React.FC = () => {
         );
         return;
       } else {
-        navigate('/verifyEmailOTP');
+        navigate(authRoutePaths.verifyEmailOtp);
       }
     };
     if (phoneVerified && !isLoginFlow) {

--- a/tests/AuthRoutes.test.tsx
+++ b/tests/AuthRoutes.test.tsx
@@ -7,7 +7,7 @@
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { AuthRoutes } from '../src/AuthRoutes';
-import { authRoutePaths, legacyAuthRouteAliases } from '../src/routes';
+import { authRoutePaths } from '../src/routes';
 
 jest.mock('@/views/Login', () => () => <div>Login Page</div>);
 jest.mock('@/views/PassKeyLogin', () => () => <div>Passkey Login Page</div>);
@@ -84,31 +84,36 @@ describe('AuthRoutes canonical paths', () => {
   });
 });
 
-describe('AuthRoutes legacy aliases', () => {
-  it.each(legacyAuthRouteAliases.map(alias => [alias.from, alias.to]))(
-    'forwards %s to %s',
-    (from, to) => {
-      renderAt(from);
-      expect(screen.getByTestId('pathname')).toHaveTextContent(to);
-    }
-  );
-
-  it('preserves the magic-link token across the legacy redirect', () => {
-    // The auth API emails this URL, so dropping the query would break sign-in.
+describe('externally owned paths', () => {
+  // The auth API builds this URL when it emails a magic link
+  // (seamless-auth-api/src/controllers/magicLinks.ts). If this path is renamed
+  // here without changing the API, every emailed link falls through to the
+  // catch-all and lands on /login with the token discarded, which silently
+  // breaks magic-link sign-in.
+  it('serves the magic-link URL the auth API emails, with its token intact', () => {
     renderAt('/verify-magiclink?token=abc123');
 
-    expect(screen.getByTestId('pathname')).toHaveTextContent(
-      authRoutePaths.verifyMagicLink
-    );
+    expect(screen.getByText('Verify Magic Link Page')).toBeInTheDocument();
     expect(screen.getByTestId('search')).toHaveTextContent('?token=abc123');
   });
 
-  it('preserves router state across the legacy redirect', () => {
-    renderAt('/magiclinks-sent', { identifier: 'user@example.com' });
+  // Registered with OAuth providers as an allowed redirect URI.
+  it('serves the OAuth callback path registered with providers', () => {
+    renderAt('/oauth/callback?code=abc&state=xyz');
 
-    expect(screen.getByTestId('pathname')).toHaveTextContent(
-      authRoutePaths.magicLinkSent
-    );
-    expect(screen.getByTestId('state')).toHaveTextContent('user@example.com');
+    expect(screen.getByText('OAuth Callback Page')).toBeInTheDocument();
+  });
+});
+
+describe('superseded paths are gone', () => {
+  it.each([
+    '/passKeyLogin',
+    '/verifyPhoneOTP',
+    '/verifyEmailOTP',
+    '/registerPasskey',
+    '/magiclinks-sent',
+  ])('%s no longer resolves and falls back to login', path => {
+    renderAt(path);
+    expect(screen.getByTestId('pathname')).toHaveTextContent(authRoutePaths.login);
   });
 });

--- a/tests/AuthRoutes.test.tsx
+++ b/tests/AuthRoutes.test.tsx
@@ -4,59 +4,111 @@
  * See LICENSE file in the project root for full license information
  */
 
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { AuthRoutes } from '../src/AuthRoutes';
+import { authRoutePaths, legacyAuthRouteAliases } from '../src/routes';
 
 jest.mock('@/views/Login', () => () => <div>Login Page</div>);
 jest.mock('@/views/PassKeyLogin', () => () => <div>Passkey Login Page</div>);
 jest.mock('@/views/PassKeyRegistration', () => () => <div>Register Passkey Page</div>);
 jest.mock('@/views/PhoneRegistration', () => () => <div>Verify Phone Page</div>);
+jest.mock('@/views/EmailRegistration', () => () => <div>Verify Email Page</div>);
+jest.mock('@/views/OAuthCallback', () => () => <div>OAuth Callback Page</div>);
+jest.mock('@/components/MagicLinkSent', () => () => <div>Magic Link Sent Page</div>);
 
-describe('AuthRoutes', () => {
-  it('renders Login page on /login', () => {
-    render(
-      <MemoryRouter initialEntries={['/login']}>
-        <AuthRoutes />
-      </MemoryRouter>
+// Reports where the router ended up, so alias redirects can be asserted on the
+// resulting location rather than only on the rendered screen.
+jest.mock('@/views/VerifyMagicLink', () => {
+  const { useLocation: useRouterLocation } = jest.requireActual('react-router-dom');
+
+  return () => {
+    const location = useRouterLocation();
+    return (
+      <div>
+        <span>Verify Magic Link Page</span>
+        <span data-testid="search">{location.search}</span>
+      </div>
     );
+  };
+});
+
+const LocationProbe = () => {
+  const location = useLocation();
+
+  return (
+    <>
+      <span data-testid="pathname">{location.pathname}</span>
+      <span data-testid="state">{JSON.stringify(location.state ?? null)}</span>
+    </>
+  );
+};
+
+const renderAt = (path: string, state?: unknown) =>
+  render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: path.split('?')[0],
+          search: path.includes('?') ? `?${path.split('?')[1]}` : '',
+          state,
+        },
+      ]}
+    >
+      <AuthRoutes />
+      <LocationProbe />
+    </MemoryRouter>
+  );
+
+describe('AuthRoutes canonical paths', () => {
+  const cases: Array<[string, string]> = [
+    [authRoutePaths.login, 'Login Page'],
+    [authRoutePaths.passkeyLogin, 'Passkey Login Page'],
+    [authRoutePaths.verifyPhoneOtp, 'Verify Phone Page'],
+    [authRoutePaths.verifyEmailOtp, 'Verify Email Page'],
+    [authRoutePaths.verifyMagicLink, 'Verify Magic Link Page'],
+    [authRoutePaths.oauthCallback, 'OAuth Callback Page'],
+    [authRoutePaths.registerPasskey, 'Register Passkey Page'],
+    [authRoutePaths.magicLinkSent, 'Magic Link Sent Page'],
+  ];
+
+  it.each(cases)('renders %s', (path, expected) => {
+    renderAt(path);
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it('redirects unknown routes to login', () => {
+    renderAt('/some/unknown/route');
     expect(screen.getByText('Login Page')).toBeInTheDocument();
+    expect(screen.getByTestId('pathname')).toHaveTextContent(authRoutePaths.login);
+  });
+});
+
+describe('AuthRoutes legacy aliases', () => {
+  it.each(legacyAuthRouteAliases.map(alias => [alias.from, alias.to]))(
+    'forwards %s to %s',
+    (from, to) => {
+      renderAt(from);
+      expect(screen.getByTestId('pathname')).toHaveTextContent(to);
+    }
+  );
+
+  it('preserves the magic-link token across the legacy redirect', () => {
+    // The auth API emails this URL, so dropping the query would break sign-in.
+    renderAt('/verify-magiclink?token=abc123');
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      authRoutePaths.verifyMagicLink
+    );
+    expect(screen.getByTestId('search')).toHaveTextContent('?token=abc123');
   });
 
-  it('renders Passkey Login page on /passKeyLogin', () => {
-    render(
-      <MemoryRouter initialEntries={['/passKeyLogin']}>
-        <AuthRoutes />
-      </MemoryRouter>
-    );
-    expect(screen.getByText('Passkey Login Page')).toBeInTheDocument();
-  });
+  it('preserves router state across the legacy redirect', () => {
+    renderAt('/magiclinks-sent', { identifier: 'user@example.com' });
 
-  it('renders Register Passkey page on /registerPasskey', () => {
-    render(
-      <MemoryRouter initialEntries={['/registerPasskey']}>
-        <AuthRoutes />
-      </MemoryRouter>
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      authRoutePaths.magicLinkSent
     );
-    expect(screen.getByText('Register Passkey Page')).toBeInTheDocument();
-  });
-
-  it('renders Phone OTP page on /verifyPhoneOTP', () => {
-    render(
-      <MemoryRouter initialEntries={['/verifyPhoneOTP']}>
-        <AuthRoutes />
-      </MemoryRouter>
-    );
-    expect(screen.getByText('Verify Phone Page')).toBeInTheDocument();
-  });
-
-  it('redirects unknown routes to /login', () => {
-    render(
-      <MemoryRouter initialEntries={['/some/unknown/route']}>
-        <AuthRoutes />
-      </MemoryRouter>
-    );
-
-    expect(screen.getByText(/Login Redirect Target|Login Page/i)).toBeInTheDocument();
+    expect(screen.getByTestId('state')).toHaveTextContent('user@example.com');
   });
 });

--- a/tests/EmailRegistration.test.tsx
+++ b/tests/EmailRegistration.test.tsx
@@ -139,7 +139,7 @@ describe('EmailRegistration', () => {
       fireEvent.click(screen.getByRole('button', { name: /verify & continue/i }));
     });
 
-    expect(navigate).toHaveBeenCalledWith('/registerPasskey');
+    expect(navigate).toHaveBeenCalledWith('/register-passkey');
   });
 
   test('successful verification logs in if passkeys not supported', async () => {
@@ -182,7 +182,7 @@ describe('EmailRegistration', () => {
     expect(mockAuthClient.verifyLoginEmailOtp).toHaveBeenCalledWith('ABCDEF');
     expect(refreshSession).toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledWith('/');
-    expect(navigate).not.toHaveBeenCalledWith('/registerPasskey');
+    expect(navigate).not.toHaveBeenCalledWith('/register-passkey');
   });
 
   test('login flow resend uses the login email OTP endpoint', async () => {

--- a/tests/PhoneRegistration.test.tsx
+++ b/tests/PhoneRegistration.test.tsx
@@ -152,7 +152,7 @@ describe('PhoneRegistration', () => {
 
     expect(mockAuthClient.requestEmailOtp).toHaveBeenCalled();
 
-    expect(navigate).toHaveBeenCalledWith('/verifyEmailOTP');
+    expect(navigate).toHaveBeenCalledWith('/verify-email-otp');
   });
 
   test('login flow verifies phone OTP and refreshes the session', async () => {

--- a/tests/login.test.tsx
+++ b/tests/login.test.tsx
@@ -208,7 +208,7 @@ describe('Login', () => {
       fireEvent.click(magicLink);
     });
 
-    expect(navigate).toHaveBeenCalledWith('/magiclinks-sent', {
+    expect(navigate).toHaveBeenCalledWith('/magic-link-sent', {
       state: { identifier: 'test@example.com' },
     });
   });
@@ -236,7 +236,7 @@ describe('Login', () => {
     });
 
     expect(mockAuthClient.requestLoginPhoneOtp).toHaveBeenCalled();
-    expect(navigate).toHaveBeenCalledWith('/verifyPhoneOTP', {
+    expect(navigate).toHaveBeenCalledWith('/verify-phone-otp', {
       state: { flow: 'login' },
     });
   });
@@ -259,7 +259,7 @@ describe('Login', () => {
     });
 
     expect(mockAuthClient.requestLoginEmailOtp).toHaveBeenCalled();
-    expect(navigate).toHaveBeenCalledWith('/verifyEmailOTP', {
+    expect(navigate).toHaveBeenCalledWith('/verify-email-otp', {
       state: { flow: 'login' },
     });
   });
@@ -297,6 +297,6 @@ describe('Login', () => {
       fireEvent.click(registerButton);
     });
 
-    expect(navigate).toHaveBeenCalledWith('/verifyEmailOTP');
+    expect(navigate).toHaveBeenCalledWith('/verify-email-otp');
   });
 });


### PR DESCRIPTION
## What

Rename the built-in `AuthRoutes` paths to a consistent kebab-case set. No aliases and no redirects: the old paths are simply gone.

| Old path           | New path            |
| ------------------ | ------------------- |
| `/passKeyLogin`    | `/passkey-login`    |
| `/verifyPhoneOTP`  | `/verify-phone-otp` |
| `/verifyEmailOTP`  | `/verify-email-otp` |
| `/registerPasskey` | `/register-passkey` |
| `/magiclinks-sent` | `/magic-link-sent`  |

Closes #21.

## Two paths deliberately not renamed

These are not naming exceptions, they are contracts owned outside this package.

**`/verify-magiclink`** is the URL the auth API builds when it emails a magic link:

```ts
// seamless-auth-api/src/controllers/magicLinks.ts:77
const redirect_url = `${frontendUrl}/verify-magiclink?token=${rawToken}`;
```

I simulated renaming it with no alias: the emailed link falls through to the catch-all and lands on `/login` with the token discarded, so magic-link sign-in breaks completely for every user. Since the API owns that URL, this package matches it rather than redirecting to a prettier one.

**`/oauth/callback`** is registered with OAuth providers as an allowed redirect URI. Renaming it would break configured integrations.

Both are pinned by tests that explain why, so a future rename cannot silently break them.

## Breaking change

Anything linking directly to an old path now falls through to `/login`. Apps that only render `AuthRoutes` and rely on its internal navigation need no change, since all internal `navigate()` calls were moved to shared constants.

## Changes

- `src/routes.ts` (new): all bundled paths in one place, so views and `AuthRoutes` cannot drift, with the external-contract constraints documented where someone would go to rename them.
- `src/AuthRoutes.tsx`: routes now keyed off those constants.
- `src/views/{Login,EmailRegistration,PhoneRegistration}.tsx`: internal `navigate()` calls use the constants instead of string literals.
- `README.md`: new path list, an old-to-new migration table, and the rationale for the two unchanged paths.
- Tests: every path renders, the two externally owned paths are pinned (including the magic-link token surviving), and each removed path is asserted to fall back to `/login`.

`routes.ts` and `AuthRoutes.tsx` are both at 100% coverage.

## Optional follow-up

If you want full kebab-case consistency including the magic-link path, it needs a coordinated change in `seamless-auth-api` to emit `/verify-magic-link`, plus a wait longer than the magic-link token TTL before this package stops serving the old path. Happy to file that if you want it.

## Checks

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Full suite: 199 passed
- Changeset (minor) documenting the breaking rename
