### PR TITLE
fix(magic-link): encode the token before using it in the request path

### DIFF
--- a/.changeset/encode-magic-link-token.md
+++ b/.changeset/encode-magic-link-token.md
@@ -1,0 +1,5 @@
+---
+'@seamless-auth/react': patch
+---
+
+Encode the magic-link token before placing it in the request path. The token is read from a link's query string, so it is untrusted input, and leaving it unencoded let path segments inside it redirect the request to a different endpoint under `/auth`. Because requests are sent with credentials, a crafted link could cause a signed-in user's browser to call unintended endpoints, including ones that send an SMS or email. Affects 0.4.0 and earlier.

--- a/src/client/createSeamlessAuthClient.ts
+++ b/src/client/createSeamlessAuthClient.ts
@@ -536,7 +536,12 @@ export const createSeamlessAuthClient = (
 
     verifyMagicLink: token =>
       requestResult<MessageResult>(
-        fetchWithAuth(`/magic-link/verify/${token}`, { method: 'GET' }),
+        // The token arrives from a link's query string, so it is untrusted
+        // input. Encoding keeps it inside its own path segment instead of
+        // letting it redirect the request to another endpoint.
+        fetchWithAuth(`/magic-link/verify/${encodeURIComponent(token)}`, {
+          method: 'GET',
+        }),
         'Failed to verify the magic link.'
       ),
 

--- a/tests/createSeamlessAuthClient.test.ts
+++ b/tests/createSeamlessAuthClient.test.ts
@@ -135,6 +135,30 @@ describe('createSeamlessAuthClient', () => {
     });
   });
 
+  it('keeps an untrusted magic-link token inside its own path segment', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: 'Success' }),
+    });
+
+    const client = createSeamlessAuthClient({
+      apiHost: 'https://api.example.com',
+    });
+
+    // The token comes from a link's query string, so an attacker controls it.
+    // Left unencoded, path segments in it re-target the request.
+    await client.verifyMagicLink('../../users/delete');
+
+    const [path] = mockFetchWithAuth.mock.calls[0];
+
+    expect(path).not.toContain('../');
+
+    // What actually matters is where the request lands once the URL resolves.
+    expect(new URL(`https://api.example.com/auth${path}`).pathname).toBe(
+      '/auth/magic-link/verify/..%2F..%2Fusers%2Fdelete'
+    );
+  });
+
   it('uses organization endpoints', async () => {
     const response = { ok: true };
     mockFetchWithAuth.mockResolvedValue(response);


### PR DESCRIPTION
## What

Encode the magic-link token before interpolating it into the request path.

```diff
- fetchWithAuth(`/magic-link/verify/${token}`, { method: 'GET' })
+ fetchWithAuth(`/magic-link/verify/${encodeURIComponent(token)}`, { method: 'GET' })
```

## Why

The token is read from a link's query string, so it is untrusted input. Unencoded, path segments inside it change where the request goes: the URL resolves away from the intended endpoint to another path under `/auth`.

Requests are sent with `credentials: 'include'`, so a crafted link opened by a signed-in user causes their browser to issue an authenticated request to an endpoint the attacker chose. Several reachable endpoints have side effects, including ones that send an SMS or an email, which makes this usable for messaging abuse rather than only as a curiosity.

This was pre-existing rather than a regression: the unencoded interpolation dates back to `595761d`, so published versions up to and including 0.4.0 are affected. It was also the only interpolated path parameter in the client without `encodeURIComponent`; every organization and OAuth path already encoded correctly.

## Tests

Added a regression test that asserts the resolved URL, not just the string, since the resolved pathname is what determines where the request actually lands. Verified it fails without the fix, reporting the traversal path, and passes with it.

## Checks

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Full suite: 206 passed
- Changeset (patch)

## Note for maintainers

Since this affects a published version of an auth package, it may warrant a GitHub security advisory alongside the 0.5.0 release rather than only a changelog line. Flagging for your call, per `SECURITY.md`.
