### PR TITLE
fix(credentials): correct credential and session response types

### DIFF
--- a/.changeset/credential-response-types.md
+++ b/.changeset/credential-response-types.md
@@ -1,0 +1,15 @@
+---
+'@seamless-auth/react': patch
+---
+
+Correct the response types for credential and session endpoints, checked against the API's response schemas.
+
+`updateCredential()` on `useAuth()` now returns the credential itself. It previously returned the `{ message, credential }` wrapper while declaring `Promise<Credential>`, so callers reading a field such as `friendlyName` got `undefined`, and the cast hid the mismatch from TypeScript.
+
+Client return types corrected to match the server schemas:
+
+- `updateCredential` returns `CredentialUpdateResult` (`{ message, credential }`), replacing `CredentialMutationResult`, which modelled `credential` as optional when the API always sends it
+- `deleteCredential` returns `MessageResult`
+- `logout`, `logoutAllSessions`, and `deleteUser` return `MessageResult` rather than being typed as returning no body
+
+`CredentialMutationResult` is removed and replaced by `CredentialUpdateResult`.

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -196,8 +196,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       throw error;
     }
 
-    // Older responses return the credential at the top level.
-    const updatedCredential = (data.credential ?? data) as Credential;
+    const updatedCredential = data.credential;
 
     setCredentials(currentCredentials =>
       currentCredentials.map(currentCredential =>
@@ -207,7 +206,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       )
     );
 
-    return data as unknown as Credential;
+    return updatedCredential;
   };
 
   const deleteCredential = async (credentialId: string) => {

--- a/src/client/createSeamlessAuthClient.ts
+++ b/src/client/createSeamlessAuthClient.ts
@@ -147,10 +147,10 @@ export interface PasskeyRegistrationData {
   prfCapable: boolean;
 }
 
-/** Response body for credential mutations. */
-export interface CredentialMutationResult {
-  credential?: Credential;
-  message?: string;
+/** Response body returned when credential metadata is updated. */
+export interface CredentialUpdateResult {
+  message: string;
+  credential: Credential;
 }
 
 export interface RegisterPasskeyOptions {
@@ -216,9 +216,9 @@ export interface SeamlessAuthClient {
   loginWithPasskey: (
     options?: PasskeyLoginOptions
   ) => Promise<SeamlessAuthResult<PasskeyLoginData>>;
-  logout: (options?: LogoutOptions) => Promise<SeamlessAuthResult<void>>;
-  logoutAllSessions: () => Promise<SeamlessAuthResult<void>>;
-  deleteUser: () => Promise<SeamlessAuthResult<void>>;
+  logout: (options?: LogoutOptions) => Promise<SeamlessAuthResult<MessageResult>>;
+  logoutAllSessions: () => Promise<SeamlessAuthResult<MessageResult>>;
+  deleteUser: () => Promise<SeamlessAuthResult<MessageResult>>;
   register: (input: RegisterInput) => Promise<SeamlessAuthResult<MessageResult>>;
   requestPhoneOtp: () => Promise<SeamlessAuthResult<MessageResult>>;
   verifyPhoneOtp: (
@@ -263,8 +263,8 @@ export interface SeamlessAuthClient {
   updateCredential: (input: {
     id: string;
     friendlyName: string | null;
-  }) => Promise<SeamlessAuthResult<CredentialMutationResult>>;
-  deleteCredential: (id: string) => Promise<SeamlessAuthResult<CredentialMutationResult>>;
+  }) => Promise<SeamlessAuthResult<CredentialUpdateResult>>;
+  deleteCredential: (id: string) => Promise<SeamlessAuthResult<MessageResult>>;
   listOrganizations: () => Promise<SeamlessAuthResult<OrganizationsResult>>;
   createOrganization: (
     input: CreateOrganizationInput
@@ -430,7 +430,7 @@ export const createSeamlessAuthClient = (
     },
 
     logout: (options = {}) =>
-      requestResult<void>(
+      requestResult<MessageResult>(
         fetchWithAuth(options.scope === 'all_sessions' ? `/logout/all` : `/logout`, {
           method: 'DELETE',
         }),
@@ -438,13 +438,13 @@ export const createSeamlessAuthClient = (
       ),
 
     logoutAllSessions: () =>
-      requestResult<void>(
+      requestResult<MessageResult>(
         fetchWithAuth(`/logout/all`, { method: 'DELETE' }),
         'Failed to sign out of all sessions.'
       ),
 
     deleteUser: () =>
-      requestResult<void>(
+      requestResult<MessageResult>(
         fetchWithAuth(`/users/delete`, { method: 'DELETE' }),
         'Failed to delete the account.'
       ),
@@ -764,7 +764,7 @@ export const createSeamlessAuthClient = (
     },
 
     updateCredential: input =>
-      requestResult<CredentialMutationResult>(
+      requestResult<CredentialUpdateResult>(
         fetchWithAuth(`users/credentials`, {
           method: 'POST',
           body: JSON.stringify(input),
@@ -773,7 +773,7 @@ export const createSeamlessAuthClient = (
       ),
 
     deleteCredential: id =>
-      requestResult<CredentialMutationResult>(
+      requestResult<MessageResult>(
         fetchWithAuth(`users/credentials`, {
           method: 'DELETE',
           body: JSON.stringify({ id }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { AuthContextType, AuthProvider, useAuth } from '@/AuthProvider';
 import { AuthRoutes } from '@/AuthRoutes';
 import {
   createSeamlessAuthClient,
-  CredentialMutationResult,
+  CredentialUpdateResult,
   CreateOrganizationInput,
   CurrentUserResult,
   FinishOAuthLoginInput,
@@ -68,7 +68,7 @@ export {
   usePasskeySupport,
 };
 export type {
-  CredentialMutationResult,
+  CredentialUpdateResult,
   AuthContextType,
   Credential,
   CreateOrganizationInput,

--- a/tests/authProvider.test.tsx
+++ b/tests/authProvider.test.tsx
@@ -364,6 +364,55 @@ describe('AuthProvider', () => {
     ).toHaveLength(1);
   });
 
+  it('returns the credential itself rather than the response wrapper', async () => {
+    let auth: ReturnType<typeof useAuth> | null = null;
+
+    const Capture = () => {
+      auth = useAuth();
+      return null;
+    };
+
+    const credential = buildCredential();
+    const updatedCredential = buildCredential({ friendlyName: 'Renamed passkey' });
+
+    mockFetchWithAuthImpl
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          user: { id: '1', email: 'test@example.com', phone: '', roles: [] },
+          credentials: [credential],
+        }),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          message: 'Credential updated',
+          credential: updatedCredential,
+        }),
+      } as any);
+
+    await act(async () => {
+      render(
+        <AuthProvider apiHost={apiHost}>
+          <Capture />
+        </AuthProvider>
+      );
+    });
+
+    const returned = await (
+      auth as unknown as ReturnType<typeof useAuth>
+    ).updateCredential({
+      ...credential,
+      friendlyName: 'Renamed passkey',
+    });
+
+    // The API wraps the payload as { message, credential }. Returning the
+    // wrapper would hand callers an object with no credential fields on it.
+    expect(returned).toEqual(updatedCredential);
+    expect(returned.friendlyName).toBe('Renamed passkey');
+    expect(returned).not.toHaveProperty('message');
+  });
+
   describe('finishOAuthLogin failures', () => {
     const renderAndCaptureAuth = async () => {
       let auth: ReturnType<typeof useAuth> | null = null;


### PR DESCRIPTION
## What

Fix `updateCredential` returning the response wrapper while claiming to return a `Credential`, and correct four other response types that did not match the server.

Closes #88.

## Resolved from the API schemas, not guessed

The issue asked to confirm the real shape against a running server. The route definitions in `seamless-auth-api` declare response schemas, which settles it without needing one:

| Endpoint | Declared schema | Was typed as |
| -------- | --------------- | ------------ |
| `POST /users/credentials` | `{ message, credential }`, `credential` required | `{ credential?, message? }` |
| `DELETE /users/credentials` | `MessageSchema` | `{ credential?, message? }` |
| `DELETE /users/delete` | `MessageSchema` | no body |
| `DELETE /logout` | `MessageSchema` | no body |
| `DELETE /logout/all` | `MessageSchema` | no body |

So the credential is always wrapped and always present, which answers the open question in the issue: the `data.credential ?? data` fallback was dead code, and the branch that ran was the one returning the wrapper.

## Changes

- `AuthProvider.updateCredential` returns `data.credential`, so `Promise<Credential>` is now true. The `as unknown as Credential` cast and the `??` fallback are gone.
- `CredentialMutationResult` is replaced by `CredentialUpdateResult` (`{ message, credential }`), which models `credential` as required.
- `deleteCredential` returns `MessageResult`.
- `logout`, `logoutAllSessions`, and `deleteUser` return `MessageResult` instead of being typed as returning no body.

The last three were found while checking the credential routes. They are the same class of defect, so they are fixed here rather than left for #90.

## Tests

Added a provider test asserting the returned value is the credential, not the wrapper. Verified it fails without the fix, receiving `{ message: 'Credential updated', ... }`, and passes with it. The existing state-merge test already covered the wrapped shape and still passes unchanged.

## Note

`MessageSchema` also carries optional `token` and `delivery` fields. `MessageResult` intentionally models only `message`, since extra response fields are harmless structurally. If a consumer needs `delivery`, that is a small follow-up.

## Checks

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Full suite: 207 passed
- Changeset (patch)
