### PR TITLE
fix(client)!: request magic links over POST

### DIFF
--- a/.changeset/magic-link-post.md
+++ b/.changeset/magic-link-post.md
@@ -1,0 +1,11 @@
+---
+'@seamless-auth/react': minor
+---
+
+Request magic links over `POST /auth/magic-link` instead of `GET`.
+
+`GET /auth/magic-link` was a state-changing route reachable as a simple cross-site request, so an `<img src>` on any page could trigger unbounded magic-link emails to a signed-in user. The Express adapter removed the GET route and replaced it with POST.
+
+The request now carries an empty JSON body. The adapter ignores it, but the resulting JSON content type forces a CORS preflight, which is what actually keeps the route from being reachable cross-site. A bodyless POST would still be a simple request.
+
+BREAKING: this release requires an adapter with the POST route (`@seamless-auth/express` 0.9.0 or later). Against an older adapter, `requestMagicLink` gets a 404. Callers of `requestMagicLink()` need no code change.

--- a/src/client/createSeamlessAuthClient.ts
+++ b/src/client/createSeamlessAuthClient.ts
@@ -538,9 +538,12 @@ export const createSeamlessAuthClient = (
         'Failed to verify the email code.'
       ),
 
+    // Sends an empty JSON body on purpose. The adapter ignores it, but it makes
+    // fetchWithAuth declare a JSON content type, which forces a CORS preflight.
+    // A bodyless POST is still a simple request and stays reachable cross-site.
     requestMagicLink: () =>
       requestResult<MessageResult>(
-        fetchWithAuth(`/magic-link`, { method: 'GET' }),
+        fetchWithAuth(`/magic-link`, { method: 'POST', body: JSON.stringify({}) }),
         'Failed to send the magic link.'
       ),
 

--- a/tests/createSeamlessAuthClient.test.ts
+++ b/tests/createSeamlessAuthClient.test.ts
@@ -135,6 +135,26 @@ describe('createSeamlessAuthClient', () => {
     });
   });
 
+  // A GET here was CSRF-able: an img tag on any page triggered magic-link
+  // emails to the victim. The JSON body is what forces the preflight.
+  it('requests a magic link over POST with a content type that forces a preflight', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: 'Success' }),
+    });
+
+    const client = createSeamlessAuthClient({
+      apiHost: 'https://api.example.com',
+    });
+
+    expect((await client.requestMagicLink()).error).toBeNull();
+
+    expect(mockFetchWithAuth).toHaveBeenCalledWith('/magic-link', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
+  });
+
   it('keeps an untrusted magic-link token inside its own path segment', async () => {
     mockFetchWithAuth.mockResolvedValue({
       ok: true,
@@ -263,7 +283,8 @@ describe('createSeamlessAuthClient', () => {
       method: 'DELETE',
     });
     expect(mockFetchWithAuth).toHaveBeenNthCalledWith(2, '/magic-link', {
-      method: 'GET',
+      method: 'POST',
+      body: JSON.stringify({}),
     });
   });
 


### PR DESCRIPTION
Closes #93

Follow-on to fells-code/seamless-auth-server#103, which removed `GET /auth/magic-link` from the Express adapter and replaced it with `POST /auth/magic-link`.

`GET /auth/magic-link` was a state-changing route reachable as a simple cross-site request. With the `SameSite=None` cookie default and no CSRF or Origin check, an `<img src="https://api.example.com/auth/magic-link">` on any page triggered unbounded magic-link emails to a signed-in user: mailbox flooding, sender-reputation damage, and phishing cover.

## Change

`requestMagicLink` in `src/client/createSeamlessAuthClient.ts` now issues a POST.

It also sends an empty JSON body, which is worth calling out because it is not obvious. `fetchWithAuth` only declares `Content-Type: application/json` when a body is actually present (`src/fetchWithAuth.ts`). A bodyless POST therefore sends no content type, which is still a CORS *simple* request: no preflight, so it stays reachable cross-site via `fetch(url, { method: 'POST', credentials: 'include', mode: 'no-cors' })`. Flipping the verb alone would have looked like a fix without being one. The JSON content type is what forces the preflight and actually closes the vector.

The adapter ignores the body (identity comes from the pre-auth cookie), and every other POST in this client already sends a JSON body, so adopter CORS configs already permit the header.

## Not changed

Audited the rest of the client:

- `logout` and `logoutAllSessions` already use `DELETE /logout` and `DELETE /logout/all`. The adapter's removal of `GET /logout` does not affect them.
- `checkMagicLink` (`GET /magic-link/check`) is unchanged in the adapter.
- `verifyMagicLink` (`GET /magic-link/verify/:token`) stays GET on purpose. The path token is the credential and it arrives from an email link.

## Tests

Added a case asserting `requestMagicLink` calls `/magic-link` with `method: 'POST'` and the JSON body. No existing test pinned the verb, which is why the SDK could have drifted from the adapter unnoticed.

Verified the test is not vacuous: reverting the client to `method: 'GET'` fails it while the other 27 suites still pass.

## Verification

```
npm run typecheck    clean
npm run lint         clean
npm run format:check all matched files use Prettier code style
npm test             28 suites / 209 tests passed
```

## Release ordering

Breaking against older adapters: `requestMagicLink` gets a 404 unless the adapter serves the POST route. fells-code/seamless-auth-server#103 must land and publish before this releases. Changeset is `minor`, matching the 0.x breaking channel.

Downstream consumers (`seamless-portal`, `seamless-review-web`, `seamless-templates`) all call `authClient.requestMagicLink()` rather than hitting the route directly, so they need only a version bump, no code change.

## Unrelated note

`package-lock.json` on `main` carries a stale `"version": "0.1.1"` while `package.json` is at `0.4.0`. Any `npm install` silently rewrites it. Kept out of this PR to stay focused; worth a separate chore commit.
