### PR TITLE
refactor: drop try/catch around client calls that cannot throw

### DIFF
--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -133,20 +133,24 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   }, []);
 
   const logout = useCallback(async () => {
+    // The client reports failures through its result, so there is nothing to
+    // catch. The finally is deliberate: local auth state has to be cleared even
+    // when the server call fails, otherwise the UI keeps presenting a signed-in
+    // user whose session is already gone.
     try {
       await authClient.logout();
-    } catch {
-      console.error('Error during logout');
     } finally {
       resetAuthState();
     }
   }, [authClient, resetAuthState]);
 
   const logoutAllSessions = useCallback(async () => {
+    // The client reports failures through its result, so there is nothing to
+    // catch. The finally is deliberate: local auth state has to be cleared even
+    // when the server call fails, otherwise the UI keeps presenting a signed-in
+    // user whose session is already gone.
     try {
       await authClient.logoutAllSessions();
-    } catch {
-      console.error('Error during logout');
     } finally {
       resetAuthState();
     }

--- a/src/components/MagicLinkSent.tsx
+++ b/src/components/MagicLinkSent.tsx
@@ -71,7 +71,8 @@ const MagicLinkSent: React.FC = () => {
           navigate('/');
         }
       } catch {
-        /* ignore */
+        // A rejection inside a timer has no caller to surface it, so the poll
+        // swallows unexpected errors and simply tries again on the next tick.
       }
     }, 5000);
 

--- a/src/views/EmailRegistration.tsx
+++ b/src/views/EmailRegistration.tsx
@@ -80,6 +80,8 @@ const EmailRegistration: React.FC = () => {
         navigate('/');
       }
     } catch {
+      // Backstop for unexpected errors only. The client reports request
+      // failures through `error`, not by throwing.
       console.error('Email OTP verification failed.');
       setError('Verification failed.');
     } finally {

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -72,79 +72,58 @@ const Login: React.FC = () => {
   const register = async () => {
     setFormErrors('');
 
-    try {
-      const { data, error } = await authClient.register({
-        email,
-        phone,
-        bootstrapToken,
-      });
+    const { data, error } = await authClient.register({
+      email,
+      phone,
+      bootstrapToken,
+    });
 
-      if (error) {
-        setFormErrors('Failed to register. Please try again.');
-        return;
-      }
-
-      if (data.message === 'Success') {
-        navigate(authRoutePaths.verifyEmailOtp);
-        return;
-      }
-      setFormErrors(
-        'An unexpected error occurred. Try again. If the problem persists, contact support.'
-      );
-    } catch {
-      console.error('Unexpected login error.');
-      setFormErrors(
-        'An unexpected error occurred. Try again. If the problem persists, contact support.'
-      );
+    if (error) {
+      setFormErrors('Failed to register. Please try again.');
+      return;
     }
+
+    if (data.message !== 'Success') {
+      setFormErrors(
+        'An unexpected error occurred. Try again. If the problem persists, contact support.'
+      );
+      return;
+    }
+
+    navigate(authRoutePaths.verifyEmailOtp);
   };
 
   const sendMagicLink = async () => {
-    try {
-      const { error } = await authClient.requestMagicLink();
+    const { error } = await authClient.requestMagicLink();
 
-      if (error) {
-        setFormErrors('Failed to send magic link.');
-        return;
-      }
-
-      navigate(authRoutePaths.magicLinkSent, { state: { identifier } });
-    } catch {
-      console.error('Failed to send magic link.');
+    if (error) {
       setFormErrors('Failed to send magic link.');
+      return;
     }
+
+    navigate(authRoutePaths.magicLinkSent, { state: { identifier } });
   };
 
   const sendPhoneOtp = async () => {
-    try {
-      const { error } = await authClient.requestLoginPhoneOtp();
+    const { error } = await authClient.requestLoginPhoneOtp();
 
-      if (error) {
-        setFormErrors('Failed to send OTP.');
-        return;
-      }
-
-      navigate(authRoutePaths.verifyPhoneOtp, { state: { flow: 'login' } });
-    } catch {
-      console.error('Failed to send phone OTP.');
+    if (error) {
       setFormErrors('Failed to send OTP.');
+      return;
     }
+
+    navigate(authRoutePaths.verifyPhoneOtp, { state: { flow: 'login' } });
   };
 
   const sendEmailOtp = async () => {
-    try {
-      const { error } = await authClient.requestLoginEmailOtp();
+    const { error } = await authClient.requestLoginEmailOtp();
 
-      if (error) {
-        setFormErrors('Failed to send email code.');
-        return;
-      }
-
-      navigate(authRoutePaths.verifyEmailOtp, { state: { flow: 'login' } });
-    } catch {
-      console.error('Failed to send email OTP.');
+    if (error) {
       setFormErrors('Failed to send email code.');
+      return;
     }
+
+    navigate(authRoutePaths.verifyEmailOtp, { state: { flow: 'login' } });
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -188,6 +167,8 @@ const Login: React.FC = () => {
         await register();
       }
     } catch {
+      // Backstop for unexpected errors only. The client reports request
+      // failures through `error`, not by throwing.
       console.error('Failed to continue sign-in.');
       setFormErrors('Failed to continue sign-in. Please try again.');
     }

--- a/src/views/PhoneRegistration.tsx
+++ b/src/views/PhoneRegistration.tsx
@@ -41,6 +41,8 @@ const PhoneRegistration: React.FC = () => {
     try {
       await verifyPhoneOTP();
     } catch {
+      // Backstop for unexpected errors only. The client reports request
+      // failures through `error`, not by throwing.
       setError('Unexpected error occurred.');
     } finally {
       setLoading(false);
@@ -49,27 +51,23 @@ const PhoneRegistration: React.FC = () => {
 
   const verifyPhoneOTP = async () => {
     setLoading(true);
-    try {
-      if (!phoneVerified) {
-        const { error } = isLoginFlow
-          ? await authClient.verifyLoginPhoneOtp(phoneOtp)
-          : await authClient.verifyPhoneOtp(phoneOtp);
 
-        if (error) {
-          setError('Verification failed.');
-        } else {
-          if (isLoginFlow) {
-            await refreshSession();
-            navigate('/');
-            return;
-          }
+    if (!phoneVerified) {
+      const { error } = isLoginFlow
+        ? await authClient.verifyLoginPhoneOtp(phoneOtp)
+        : await authClient.verifyPhoneOtp(phoneOtp);
 
-          setPhoneVerified(true);
+      if (error) {
+        setError('Verification failed.');
+      } else {
+        if (isLoginFlow) {
+          await refreshSession();
+          navigate('/');
+          return;
         }
+
+        setPhoneVerified(true);
       }
-    } catch {
-      console.error('Phone OTP verification failed.');
-      setError('Verification failed.');
     }
 
     setLoading(false);

--- a/src/views/VerifyMagicLink.tsx
+++ b/src/views/VerifyMagicLink.tsx
@@ -36,24 +36,20 @@ const VerifyMagicLink: React.FC = () => {
         return;
       }
 
-      try {
-        const { error } = await authClient.verifyMagicLink(token);
+      const { error } = await authClient.verifyMagicLink(token);
 
-        if (error) {
-          console.error('Failed to verify token');
-          if (mounted) {
-            setError('Failed to verify token');
-          }
-          return;
+      if (error) {
+        console.error('Failed to verify token');
+        if (mounted) {
+          setError('Failed to verify token');
         }
-
-        // The verify call sets the session cookie for this browser. Sync
-        // provider state here so the tab that completed verification lands
-        // authenticated instead of relying on another tab or a manual reload.
-        await refreshSession();
-      } catch {
-        console.error('Failed to verify magic-link token.');
+        return;
       }
+
+      // The verify call sets the session cookie for this browser. Sync
+      // provider state here so the tab that completed verification lands
+      // authenticated instead of relying on another tab or a manual reload.
+      await refreshSession();
 
       if (!mounted) {
         return;

--- a/tests/authProvider.test.tsx
+++ b/tests/authProvider.test.tsx
@@ -171,7 +171,11 @@ describe('AuthProvider', () => {
   });
 
   it('logs out if token validation fails (bad response)', async () => {
-    mockFetchWithAuthImpl.mockResolvedValueOnce({ ok: false } as any);
+    // Both calls need a response: the failed /users/me, and the logout that
+    // follows it.
+    mockFetchWithAuthImpl
+      .mockResolvedValueOnce({ ok: false, status: 401, json: async () => ({}) } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any);
 
     await act(async () => {
       render(
@@ -187,7 +191,9 @@ describe('AuthProvider', () => {
   });
 
   it('logs out if token validation throws', async () => {
-    mockFetchWithAuthImpl.mockRejectedValueOnce(new Error('network down'));
+    mockFetchWithAuthImpl
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any);
 
     await act(async () => {
       render(


### PR DESCRIPTION
## What

Remove the `try`/`catch` blocks that guarded client calls which can no longer throw, and document the few that are kept on purpose.

Closes #89.

## Removed

Six unreachable handlers, all wrapping nothing but client calls whose failures already arrive through `error`:

- `AuthProvider`: the `catch` in `logout` and `logoutAllSessions`
- `Login`: `register`, `sendMagicLink`, `sendPhoneOtp`, `sendEmailOtp`
- `PhoneRegistration`: the inner `verifyPhoneOTP` handler
- `VerifyMagicLink`: the verify handler

## Kept, with a comment saying why

Not every `catch` here was dead, so these stay and now explain themselves rather than implying the client throws:

- `Login`, `PhoneRegistration`, and `EmailRegistration` submit handlers, as backstops for genuinely unexpected errors
- the `MagicLinkSent` poll, because a rejection inside a timer has no caller to surface it

Untouched elsewhere, because they guard code that really does throw: `startAuthentication` and `startRegistration` (a cancelled prompt), `response.json()` and the fetch promise in the result layer, `localStorage` in private mode, `Intl` in `phoneInput`, and `startOAuthLogin` in `OAuthProviderButtons`, which is a provider helper and therefore throws by design.

## `logout` keeps its guarantee

`logout` and `logoutAllSessions` became `try`/`finally` rather than losing the block entirely. The `catch` was dead, but the `finally` is load-bearing: local auth state must be cleared even when the server call fails, or the UI keeps presenting a signed-in user whose session is gone. There is a comment on both, and the test added in #96 covers it.

## This exposed two tests that were passing for the wrong reason

`logs out if token validation fails (bad response)` and `logs out if token validation throws` both mocked only the `/users/me` call. `validateToken` then calls `logout()`, whose request was never mocked and resolved `undefined`, which made `requestResult` throw a `TypeError` while reading `response.ok`. The old `catch` in `logout` swallowed it, so the tests passed while asserting less than they appeared to.

With the `catch` gone the `TypeError` surfaced, so both mocks now provide the logout response as well. The assertions are unchanged and now actually exercise the path they describe.

Worth noting the underlying detail: `requestResult` assumes the request promise resolves to a `Response`. That only breaks under a bad mock or a broken fetch shim, so I did not add speculative defence, but it is the reason those tests failed the moment the catch went away.

## Checks

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Full suite: 221 passed
- Coverage improved as dead branches disappeared: `Login.tsx` 73.3% to 76.9% statements, `PhoneRegistration.tsx` 89.4% to 91.5%, `VerifyMagicLink.tsx` 93.9% to 95.7%, repo overall 88.9% to 89.7%
- No changeset: no behavior change for adopters
