### PR TITLE
fix(client)!: request OTP generation over POST

### DIFF
--- a/.changeset/otp-generate-post.md
+++ b/.changeset/otp-generate-post.md
@@ -1,0 +1,9 @@
+---
+'@seamless-auth/react': minor
+---
+
+Request OTP generation over `POST` instead of `GET`.
+
+`requestPhoneOtp`, `requestEmailOtp`, `requestLoginPhoneOtp`, and `requestLoginEmailOtp` each caused an SMS or email to be sent, so they were state changing. Sent as a `GET`, they were simple cross-site requests, so an `<img src>` on any page could trigger unbounded OTP messages to a signed-in user. They now POST an empty JSON body, which forces a CORS preflight and closes the vector. This mirrors the `requestMagicLink` change.
+
+BREAKING: this requires an adapter serving these routes over POST (`@seamless-auth/express` with the OTP POST change, released alongside this). Against an older adapter the four request methods get a 404. Callers need no code change.

--- a/src/client/createSeamlessAuthClient.ts
+++ b/src/client/createSeamlessAuthClient.ts
@@ -480,7 +480,13 @@ export const createSeamlessAuthClient = (
 
     requestPhoneOtp: () =>
       requestResult<MessageResult>(
-        fetchWithAuth(`/otp/generate-phone-otp`, { method: 'GET' }),
+        // POST with an empty JSON body on purpose. These routes send an SMS or
+        // email, so they are state changing. The JSON content type forces a CORS
+        // preflight, which keeps them from being triggered by a cross-site GET.
+        fetchWithAuth(`/otp/generate-phone-otp`, {
+          method: 'POST',
+          body: JSON.stringify({}),
+        }),
         'Failed to send the SMS code.'
       ),
 
@@ -495,7 +501,13 @@ export const createSeamlessAuthClient = (
 
     requestLoginPhoneOtp: () =>
       requestResult<MessageResult>(
-        fetchWithAuth(`/otp/generate-login-phone-otp`, { method: 'GET' }),
+        // POST with an empty JSON body on purpose. These routes send an SMS or
+        // email, so they are state changing. The JSON content type forces a CORS
+        // preflight, which keeps them from being triggered by a cross-site GET.
+        fetchWithAuth(`/otp/generate-login-phone-otp`, {
+          method: 'POST',
+          body: JSON.stringify({}),
+        }),
         'Failed to send the SMS code.'
       ),
 
@@ -510,7 +522,13 @@ export const createSeamlessAuthClient = (
 
     requestEmailOtp: () =>
       requestResult<MessageResult>(
-        fetchWithAuth(`/otp/generate-email-otp`, { method: 'GET' }),
+        // POST with an empty JSON body on purpose. These routes send an SMS or
+        // email, so they are state changing. The JSON content type forces a CORS
+        // preflight, which keeps them from being triggered by a cross-site GET.
+        fetchWithAuth(`/otp/generate-email-otp`, {
+          method: 'POST',
+          body: JSON.stringify({}),
+        }),
         'Failed to send the email code.'
       ),
 
@@ -525,7 +543,13 @@ export const createSeamlessAuthClient = (
 
     requestLoginEmailOtp: () =>
       requestResult<MessageResult>(
-        fetchWithAuth(`/otp/generate-login-email-otp`, { method: 'GET' }),
+        // POST with an empty JSON body on purpose. These routes send an SMS or
+        // email, so they are state changing. The JSON content type forces a CORS
+        // preflight, which keeps them from being triggered by a cross-site GET.
+        fetchWithAuth(`/otp/generate-login-email-otp`, {
+          method: 'POST',
+          body: JSON.stringify({}),
+        }),
         'Failed to send the email code.'
       ),
 

--- a/tests/createSeamlessAuthClient.test.ts
+++ b/tests/createSeamlessAuthClient.test.ts
@@ -103,14 +103,37 @@ describe('createSeamlessAuthClient', () => {
     expect(mockFetchWithAuth).toHaveBeenNthCalledWith(
       1,
       '/otp/generate-login-phone-otp',
-      {
-        method: 'GET',
-      }
+      { method: 'POST', body: JSON.stringify({}) }
     );
     expect(mockFetchWithAuth).toHaveBeenNthCalledWith(2, '/otp/verify-login-phone-otp', {
       method: 'POST',
       body: JSON.stringify({ verificationToken: '123456' }),
     });
+  });
+
+  it('requests OTP generation over POST so the routes are not simple GETs', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: 'Success' }),
+    });
+
+    const client = createSeamlessAuthClient({
+      apiHost: 'https://api.example.com',
+    });
+
+    await client.requestPhoneOtp();
+    await client.requestEmailOtp();
+    await client.requestLoginPhoneOtp();
+    await client.requestLoginEmailOtp();
+
+    // A bodyless GET would be a simple cross-site request. POST with a JSON body
+    // forces a preflight, which is the whole point of the change.
+    for (const [path] of mockFetchWithAuth.mock.calls) {
+      expect(path).toMatch(/\/otp\/generate-/);
+    }
+    for (const [, init] of mockFetchWithAuth.mock.calls) {
+      expect(init).toEqual({ method: 'POST', body: JSON.stringify({}) });
+    }
   });
 
   it('uses login-specific email OTP endpoints', async () => {
@@ -127,7 +150,7 @@ describe('createSeamlessAuthClient', () => {
     expect(mockFetchWithAuth).toHaveBeenNthCalledWith(
       1,
       '/otp/generate-login-email-otp',
-      expect.objectContaining({ method: 'GET' })
+      { method: 'POST', body: JSON.stringify({}) }
     );
     expect(mockFetchWithAuth).toHaveBeenNthCalledWith(2, '/otp/verify-login-email-otp', {
       method: 'POST',


### PR DESCRIPTION
## What

Request OTP generation over `POST` instead of `GET` for all four generate methods, closing the same CSRF vector fixed for `requestMagicLink`.

- `requestPhoneOtp`, `requestEmailOtp`, `requestLoginPhoneOtp`, `requestLoginEmailOtp`

Closes #101.

## Why

Each of these methods causes an SMS or email to be sent, so they are state changing. As a bodyless `GET`, they were simple cross-site requests, so an `<img src>` on any page could trigger unbounded OTP messages to a signed-in user (SMS toll fraud and inbox spam). I confirmed the precondition against the adapter: the session cookie defaults to `SameSite=None` in a secure deployment, so it rides along on cross-site GETs.

Each now sends `POST` with an empty JSON body. The body is what matters: it makes `fetchWithAuth` declare a JSON content type, which forces a CORS preflight and makes the route unreachable cross-site. A bodyless POST would still be a simple request. This mirrors the `requestMagicLink` fix exactly.

## Coordinated release

BREAKING. The adapter half is fells-code/seamless-auth-server#109, which serves these routes over POST. The two must ship together: an older adapter 404s this SDK, and an older SDK issuing GET 404s against the new adapter. Same lockstep as the magic-link change tracked in #100.

## Tests

- The existing login OTP endpoint assertions now expect `POST` with an empty JSON body
- Added a focused test asserting all four generate methods POST a JSON body rather than issuing a simple GET, with a comment on why that closes the vector

Full suite: 223 passed.

## Checks

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Changeset (minor, breaking, requires the paired adapter)
