### PR TITLE
chore(deps): raise react-router-dom peer floor past security advisory

### DIFF
--- a/.changeset/react-router-security-floor.md
+++ b/.changeset/react-router-security-floor.md
@@ -1,0 +1,7 @@
+---
+'@seamless-auth/react': patch
+---
+
+Raise the `react-router-dom` v7 peer floor to `^7.15.1` to steer adopters off versions affected by a high-severity advisory (GHSA in react-router's vendored turbo-stream, affecting react-router 7.0.0 through 7.15.0). React Router 6 is unaffected, so the `^6.4.0` range is unchanged.
+
+This is a peer range change, so adopters on a vulnerable v7 (7.0.0 to 7.15.0) will see an npm warning until they upgrade to 7.15.1 or later. No SDK code change and no runtime behavior change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
-        "react-router-dom": "^6.4.0 || ^7.0.0"
+        "react-router-dom": "^6.4.0 || ^7.15.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -11336,9 +11336,9 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -11359,13 +11359,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
-      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "react-router": "7.13.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "react-router-dom": "^6.4.0 || ^7.0.0"
+    "react-router-dom": "^6.4.0 || ^7.15.1"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",


### PR DESCRIPTION
## What

Raise the `react-router-dom` v7 peer floor from `^7.0.0` to `^7.15.1` to steer adopters past a high-severity advisory, and refresh the lockfile so this repo's own install uses the fixed version.

## The advisory

`react-router` 7.0.0 through 7.15.0 has a high-severity issue in its vendored turbo-stream (arbitrary constructor invocation via deserialization). Our peer range `^7.0.0` permitted the entire vulnerable band with no floor. React Router 6 is unaffected, so `^6.4.0` is unchanged.

- Peer floor: `^6.4.0 || ^7.0.0` -> `^6.4.0 || ^7.15.1`
- Lockfile: `react-router` 7.13.0 -> 7.18.1

`npm audit` no longer reports react-router. The suite passes on 7.18.1 (the SDK uses only stable declarative APIs: `useNavigate`, `useHref`, `useSearchParams`, `Routes`, `Route`, `MemoryRouter`), and the packed output is unchanged.

## Why a peer bump rather than a pin

`react-router-dom` is a peer dependency, so adopters resolve their own copy and the SDK cannot pin it for them. Raising the floor is the available lever: npm warns an adopter still on a vulnerable v7 until they move to 7.15.1 or later. The lockfile change only affects this repo's CI and dev install.

## Separate finding, not fixed here

While tracing the audit I found a residual moderate (`js-yaml`) in the production dependency tree, reachable through `eslint-plugin-license-header` -> `eslint` -> `js-yaml`. The root cause is that `eslint-plugin-license-header` and `ts-node` are declared in `dependencies` rather than `devDependencies`. They are lint and build tooling, so they should not be runtime dependencies: today every adopter installs the full eslint toolchain (and its vulnerable js-yaml) transitively for no reason.

That is a `dependencies` reorganization rather than a security patch bump, and it wants its own verification (confirm nothing in the build path needs them at runtime), so I kept it out of this PR. Worth a focused follow-up. Flagging rather than filing per the current workflow.

## Checks

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Full suite: 223 passed on react-router 7.18.1
- `npm audit` no longer reports react-router
- `npm run check-npm-build`: packed output unchanged
- Changeset (patch)
