### PR TITLE
chore(client)!: drop the dead bootstrapToken register field

### DIFF
--- a/.changeset/remove-bootstrap-token.md
+++ b/.changeset/remove-bootstrap-token.md
@@ -1,0 +1,9 @@
+---
+'@seamless-auth/react': minor
+---
+
+Remove the admin bootstrap invite path from registration.
+
+The Seamless Auth API dropped the bootstrap invite flow, so `POST /registration/register` no longer accepts a `bootstrapToken`. The field was silently stripped by the API's non-strict body schema, which made the client code dead: the bundled login screen read a `bootstrapToken` query parameter and forwarded it, and the value went nowhere.
+
+BREAKING: `RegisterInput.bootstrapToken` is gone. It was optional, so callers that never set it need no change. Callers that did pass it should drop the field, since nothing on the server consumed it.

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ For production providers, configure exact `redirectUris` on the Seamless Auth AP
 send the callback URL it expects to receive, but redirect allowlisting, signed state expiry, OIDC
 nonce handling, email verification policy, and account-linking policy are enforced by the API.
 
-The built-in views avoid logging OTPs, magic-link tokens, bootstrap tokens, PRF salts, or raw
+The built-in views avoid logging OTPs, magic-link tokens, PRF salts, or raw
 exception payloads that may contain sensitive request URLs.
 
 ## Headless Client

--- a/src/client/createSeamlessAuthClient.ts
+++ b/src/client/createSeamlessAuthClient.ts
@@ -50,7 +50,6 @@ export interface RegisterInput {
   // Registration only needs an email. A phone can be added and verified later,
   // so it is optional here and only sent when a caller supplies one.
   phone?: string | null;
-  bootstrapToken?: string | null;
 }
 
 export interface PasskeyMetadata {
@@ -474,7 +473,6 @@ export const createSeamlessAuthClient = (
           body: JSON.stringify({
             email: input.email,
             ...(input.phone ? { phone: input.phone } : {}),
-            ...(input.bootstrapToken ? { bootstrapToken: input.bootstrapToken } : {}),
           }),
         }),
         'Failed to register.'

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -31,18 +31,10 @@ const Login: React.FC = () => {
   const [identifierError, setIdentifierError] = useState<string>('');
   const [showFallbackOptions, setShowFallbackOptions] = useState(false);
   const [loginMethods, setLoginMethods] = useState<LoginMethod[]>(DEFAULT_LOGIN_METHODS);
-  const [bootstrapToken, setBootstrapToken] = useState<string | null>(null);
 
   useEffect(() => {
     if (hasSignedInBefore) {
       setMode('login');
-    }
-
-    const params = new URLSearchParams(window.location.search);
-    const token = params.get('bootstrapToken');
-
-    if (token && token.length > 10) {
-      setBootstrapToken(token);
     }
   }, [hasSignedInBefore]);
 
@@ -70,7 +62,6 @@ const Login: React.FC = () => {
 
     const { data, error } = await authClient.register({
       email,
-      bootstrapToken,
     });
 
     if (error) {


### PR DESCRIPTION
## Summary

`seamless-auth-api` removed the admin bootstrap invite flow ([fells-code/seamless-auth-api#112](https://github.com/fells-code/seamless-auth-api/pull/112)), so `POST /registration/register` no longer has a `bootstrapToken` field. The API's non-strict Zod body schema silently strips it, so nothing broke at runtime, but the client code became dead: the bundled login screen still read a `bootstrapToken` query parameter, held it in state, and forwarded it into the register call for nothing.

This removes that path.

## Changes

- `src/views/Login.tsx`: drop the `bootstrapToken` state, the `params.get('bootstrapToken')` read, and passing it into `authClient.register()`. The `useEffect` now only handles the `hasSignedInBefore` mode switch.
- `src/client/createSeamlessAuthClient.ts`: drop `bootstrapToken?: string | null` from `RegisterInput` and the conditional spread that forwarded it in the request body.
- `README.md`: the sensitive-logging note no longer mentions bootstrap tokens.
- Changeset added (minor, with a BREAKING note).

No tests referenced `bootstrapToken`, so none needed updating.

`RegisterInput.bootstrapToken` was optional, so callers that never set it are unaffected. Callers that did pass it now get a type error and should drop the field, since the server was already ignoring it.

## Verification

- `npm run typecheck`: clean
- `npm run lint`: clean
- `npm run format:check`: all matched files use Prettier code style
- `npm test -- --runInBand`: 28 suites, 223 tests, all passing
- `npm run build`: succeeds, and `dist/index.d.ts` has no `bootstrapToken`