### PR TITLE
feat(oauth): surface OAuth callback error codes in sign-in messaging

### DIFF
--- a/.changeset/olive-jokes-report.md
+++ b/.changeset/olive-jokes-report.md
@@ -1,0 +1,5 @@
+---
+'@seamless-auth/react': minor
+---
+
+Surface OAuth callback error codes. A new `getOAuthErrorCode()` export reads the auth API's machine-readable `code` off a `SeamlessAuthError` and narrows it to `oauth_missing_email`, `oauth_email_not_verified`, or `oauth_missing_subject`, returning `undefined` for anything unrecognized. The bundled OAuth callback screen now maps those three codes to actionable text instead of one generic failure message.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Runtime exports currently include:
 - `usePasskeySupport`
 - `hasScopedRole` and `roleGrantsAccess`
 - `encodePrfSalt`, `extractPasskeyPrfResult`, and `isPasskeyPrfSupported`
-- `SeamlessAuthError`
+- `SeamlessAuthError` and `getOAuthErrorCode`
 
 Every request method on the client and the provider resolves to a
 `SeamlessAuthResult<T>` (`{ data, error }`) and does not throw for HTTP or
@@ -129,7 +129,7 @@ domain models, for example:
 - `PasskeyMetadata`, `PasskeyLoginData`, `PasskeyRegistrationData`, `RegisterPasskeyOptions`
 - `PasskeyPrfInput`, `PasskeyPrfResult`
 - Credential types: `CredentialUpdateResult`
-- OAuth types: `OAuthProvider`, `OAuthProvidersResult`, `StartOAuthLoginInput`, `StartOAuthLoginResult`, `FinishOAuthLoginInput`
+- OAuth types: `OAuthProvider`, `OAuthProvidersResult`, `StartOAuthLoginInput`, `StartOAuthLoginResult`, `FinishOAuthLoginInput`, `OAuthErrorCode`
 - Organization types: `CreateOrganizationInput`, `UpdateOrganizationInput`, `OrganizationMemberInput`, `OrganizationMemberUpdateInput`, `OrganizationsResult`, `OrganizationResult`, `OrganizationMembersResult`, `OrganizationMembershipResult`, `OrganizationSwitchResult`
 - Step-up types: `StepUpMethod`, `StepUpStatus`, `StepUpPrfData`
 - `SeamlessAuthClient` and `SeamlessAuthClientOptions`

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - `usePasskeySupport()`
 - `hasScopedRole()` and `roleGrantsAccess()`
 - `SeamlessAuthError`, the error type carried on a failed result
+- `getOAuthErrorCode()`, which reads the known OAuth callback failure codes off that error
 - types including `AuthContextType`, `Credential`, `User`, `OAuthProvider`, `StepUpStatus`, the `SeamlessAuthResult` wrapper, and the headless client input/result types
 
 ## Installation
@@ -383,6 +384,33 @@ function OAuthCallback() {
   return <p>Finishing sign-in...</p>;
 }
 ```
+
+Some callback failures are the user's to fix, so the API returns a stable `code` alongside the error
+message. `getOAuthErrorCode()` narrows it to the codes this SDK knows about and returns `undefined`
+for everything else, so unexpected failures keep your generic message:
+
+```tsx
+import { getOAuthErrorCode, useAuth } from '@seamless-auth/react';
+
+const { error } = await finishOAuthLogin({ providerId, code, state });
+
+switch (getOAuthErrorCode(error)) {
+  case 'oauth_missing_email':
+    // The provider account shared no email address.
+    break;
+  case 'oauth_email_not_verified':
+    // The provider account's email is unverified.
+    break;
+  case 'oauth_missing_subject':
+    // The provider returned no usable account identifier.
+    break;
+  default:
+    // No error, or one without a recognized code.
+    break;
+}
+```
+
+The bundled `AuthRoutes` callback screen already maps these three codes to actionable text.
 
 For fully custom UI without `useAuth()`, call the headless client directly:
 

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -20,6 +20,42 @@ export class SeamlessAuthError extends Error {
   }
 }
 
+/**
+ * Machine-readable codes the auth API returns alongside `error` on an OAuth
+ * callback failure the user can act on.
+ */
+export type OAuthErrorCode =
+  | 'oauth_missing_email'
+  | 'oauth_email_not_verified'
+  | 'oauth_missing_subject';
+
+const OAUTH_ERROR_CODES = new Set<string>([
+  'oauth_missing_email',
+  'oauth_email_not_verified',
+  'oauth_missing_subject',
+]);
+
+/**
+ * Read the OAuth failure code off a result error. Returns `undefined` for
+ * anything unrecognized, including codes added by a newer API, so callers keep
+ * their generic messaging instead of showing a raw code.
+ */
+export function getOAuthErrorCode(error: unknown): OAuthErrorCode | undefined {
+  if (!(error instanceof SeamlessAuthError)) {
+    return undefined;
+  }
+
+  if (typeof error.body !== 'object' || error.body === null) {
+    return undefined;
+  }
+
+  const { code } = error.body as { code?: unknown };
+
+  return typeof code === 'string' && OAUTH_ERROR_CODES.has(code)
+    ? (code as OAuthErrorCode)
+    : undefined;
+}
+
 function extractMessage(body: unknown): string | undefined {
   if (typeof body !== 'object' || body === null) {
     return undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ import {
   TotpStatus,
   UpdateOrganizationInput,
 } from '@/client/createSeamlessAuthClient';
-import { SeamlessAuthError } from '@/client/errors';
+import { getOAuthErrorCode, OAuthErrorCode, SeamlessAuthError } from '@/client/errors';
 import type { SeamlessAuthResult } from '@/client/result';
 import {
   encodePrfSalt,
@@ -61,6 +61,7 @@ export {
   createSeamlessAuthClient,
   encodePrfSalt,
   extractPasskeyPrfResult,
+  getOAuthErrorCode,
   hasScopedRole,
   isPasskeyPrfSupported,
   roleGrantsAccess,
@@ -80,6 +81,7 @@ export type {
   LoginMethod,
   LoginStartResult,
   MessageResult,
+  OAuthErrorCode,
   OAuthProvider,
   OAuthProvidersResult,
   Organization,

--- a/src/views/OAuthCallback.tsx
+++ b/src/views/OAuthCallback.tsx
@@ -7,9 +7,21 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '@/AuthProvider';
+import { getOAuthErrorCode, OAuthErrorCode } from '@/client/errors';
 import { OAUTH_PROVIDER_STORAGE_KEY } from '@/components/OAuthProviderButtons';
 
 import styles from '@/styles/verifyMagiclink.module.css';
+
+const GENERIC_ERROR = 'We could not complete sign-in. Please try again.';
+
+const CODE_ERRORS: Record<OAuthErrorCode, string> = {
+  oauth_missing_email:
+    'Your provider account did not share an email address. Add an email to that account and make it visible, then try again.',
+  oauth_email_not_verified:
+    'The email address on your provider account is not verified. Verify it with your provider, then try again.',
+  oauth_missing_subject:
+    'Your provider did not return a usable account identifier. Try again, or sign in with a different method.',
+};
 
 const OAuthCallback: React.FC = () => {
   const { finishOAuthLogin } = useAuth();
@@ -33,7 +45,8 @@ const OAuthCallback: React.FC = () => {
 
     void finishOAuthLogin({ providerId, code, state }).then(({ error: finishError }) => {
       if (finishError) {
-        setError('We could not complete sign-in. Please try again.');
+        const code = getOAuthErrorCode(finishError);
+        setError(code ? CODE_ERRORS[code] : GENERIC_ERROR);
         return;
       }
 

--- a/tests/OAuthCallback.test.tsx
+++ b/tests/OAuthCallback.test.tsx
@@ -8,6 +8,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import OAuthCallback from '@/views/OAuthCallback';
 
 import { useAuth } from '@/AuthProvider';
+import { SeamlessAuthError } from '@/client/errors';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 jest.mock('@/AuthProvider');
@@ -55,5 +56,43 @@ describe('OAuthCallback', () => {
 
     expect(await screen.findByText('Sign-in failed')).toBeInTheDocument();
     expect(finishOAuthLogin).not.toHaveBeenCalled();
+  });
+
+  describe('callback failures', () => {
+    const renderWithError = (error: unknown) => {
+      finishOAuthLogin.mockResolvedValue({ data: null, error });
+      window.sessionStorage.setItem('seamless:oauth:provider', 'mock');
+      (useSearchParams as jest.Mock).mockReturnValue([
+        new URLSearchParams('code=abc&state=xyz'),
+      ]);
+
+      render(<OAuthCallback />);
+    };
+
+    test.each([
+      ['oauth_missing_email', /did not share an email address/],
+      ['oauth_email_not_verified', /is not verified/],
+      ['oauth_missing_subject', /usable account identifier/],
+    ])('maps %s to curated messaging', async (code, expected) => {
+      renderWithError(new SeamlessAuthError('Sign-in failed', 400, { code }));
+
+      expect(await screen.findByText(expected)).toBeInTheDocument();
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    test('falls back to the generic message for an unrecognized failure', async () => {
+      renderWithError(new SeamlessAuthError('Sign-in failed', 400, { error: 'nope' }));
+
+      expect(
+        await screen.findByText('We could not complete sign-in. Please try again.')
+      ).toBeInTheDocument();
+    });
+
+    test('keeps the provider in storage so a retry can reuse it', async () => {
+      renderWithError(new SeamlessAuthError('Sign-in failed', 500));
+
+      await screen.findByText('We could not complete sign-in. Please try again.');
+      expect(window.sessionStorage.getItem('seamless:oauth:provider')).toBe('mock');
+    });
   });
 });

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -4,7 +4,11 @@
  * See LICENSE file in the project root for full license information
  */
 
-import { SeamlessAuthError, toSeamlessAuthError } from '@/client/errors';
+import {
+  getOAuthErrorCode,
+  SeamlessAuthError,
+  toSeamlessAuthError,
+} from '@/client/errors';
 
 const responseWith = (status: number, json: () => Promise<unknown>) =>
   ({ status, json }) as unknown as Response;
@@ -62,5 +66,46 @@ describe('toSeamlessAuthError', () => {
 
     expect(error).toBeInstanceOf(Error);
     expect(error.name).toBe('SeamlessAuthError');
+  });
+});
+
+describe('getOAuthErrorCode', () => {
+  it.each(['oauth_missing_email', 'oauth_email_not_verified', 'oauth_missing_subject'])(
+    'returns the known code %s',
+    code => {
+      const error = new SeamlessAuthError('Sign-in failed', 400, {
+        error: 'Sign-in failed',
+        code,
+      });
+
+      expect(getOAuthErrorCode(error)).toBe(code);
+    }
+  );
+
+  it('ignores a code the SDK does not know', () => {
+    const error = new SeamlessAuthError('Sign-in failed', 400, {
+      code: 'oauth_something_new',
+    });
+
+    expect(getOAuthErrorCode(error)).toBeUndefined();
+  });
+
+  it('returns undefined when the body carries no code', () => {
+    expect(
+      getOAuthErrorCode(new SeamlessAuthError('Sign-in failed', 400, { error: 'nope' }))
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for a missing or non-object body', () => {
+    expect(getOAuthErrorCode(new SeamlessAuthError('nope', 500))).toBeUndefined();
+    expect(
+      getOAuthErrorCode(new SeamlessAuthError('nope', 500, 'oauth_missing_email'))
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for anything that is not a SeamlessAuthError', () => {
+    expect(getOAuthErrorCode(new Error('boom'))).toBeUndefined();
+    expect(getOAuthErrorCode({ body: { code: 'oauth_missing_email' } })).toBeUndefined();
+    expect(getOAuthErrorCode(null)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #108.

The auth API returns a stable, machine-readable `code` alongside the `error` string on the OAuth callback 400 response, and this SDK already carried the parsed body through `SeamlessAuthError.body`. Nothing read `code`, so the actionable detail never reached the user.

## Changes

- `getOAuthErrorCode()` in `src/client/errors.ts` narrows `error.body.code` to `oauth_missing_email`, `oauth_email_not_verified`, or `oauth_missing_subject`, and returns `undefined` for anything else so a newer API code cannot leak a raw string into the UI.
- `OAuthCallback` maps each known code to actionable text and keeps the generic message for everything else.
- Exported `getOAuthErrorCode` and the `OAuthErrorCode` type from `src/index.ts`, with README coverage for custom UIs.

Additive only. No existing behavior changes for errors without a recognized code.

## Validation

`npm run lint`, `npm run typecheck`, `npm run format:check`, `npm test -- --runInBand` (235 passing), `npm run build`, and `npm run check-npm-build` all pass.