### PR TITLE
feat(types): consume the response envelopes and role matching from types 0.4.0

### DIFF
--- a/.changeset/tidy-moons-tap.md
+++ b/.changeset/tidy-moons-tap.md
@@ -1,0 +1,5 @@
+---
+'@seamless-auth/react': patch
+---
+
+Take the last five response envelopes from `@seamless-auth/types` instead of declaring them here. `OAuthProvidersResult`, `CredentialUpdateResult`, `OrganizationResult`, `OrganizationMembersResult`, and `OrganizationMembershipResult` were hand-written because the package had no exported alias for their schemas; types 0.4.0 exports one for every schema, so they are aliases now like the rest. The shapes are identical, so this is a no-op for adopters, and the dependency stays types-only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,10 +117,10 @@ Rules for this dependency:
 - session material stays unexposed. `LoginStartResult` and
   `OrganizationSwitchResult` `Omit` the token, subject, and session id the API
   returns, because sessions are carried by cookies here.
-- a few shapes have upstream schemas but no exported type alias
-  (`OAuthProvidersResponse`, `CredentialUpdateResponse`, and the organization
-  envelope responses). Those stay declared locally until the package exports
-  them.
+- do not redeclare a shape the package already exports. Every exported schema has
+  a `z.infer` alias as of types 0.4.0, and a test upstream keeps it that way, so
+  a local interface mirroring a wire shape is a bug. If an alias is genuinely
+  missing, file it on `seamless-auth-types` rather than working around it.
 
 The PRF helper types and `SeamlessAuthResult` stay local: they are SDK concerns,
 not wire contracts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@seamless-auth/types": "^0.2.0",
+        "@seamless-auth/types": "^0.4.0",
         "@simplewebauthn/browser": "^13.1.0",
         "eslint-plugin-license-header": "^0.9.0",
         "libphonenumber-js": "^1.12.7",
@@ -3066,9 +3066,9 @@
       "license": "MIT"
     },
     "node_modules/@seamless-auth/types": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@seamless-auth/types/-/types-0.2.0.tgz",
-      "integrity": "sha512-4QHdkZLKFNvU8g//nDU983rmIXNsnwIPj/eXsCWmj6+FAgCcEaHhmE/U7u3ogGk7+ZuwRWagQ8aBjHqoWggovg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@seamless-auth/types/-/types-0.4.0.tgz",
+      "integrity": "sha512-1WhLjgyCN9UdX6TEzKbbASROeLMxZmo2LiAYOlYE2sGIPojnbAE/yFbp5Ydt13GibiZ6MwYlHMLcsBVQMeelWA==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "dependencies": {
-    "@seamless-auth/types": "^0.2.0",
+    "@seamless-auth/types": "^0.4.0",
     "@simplewebauthn/browser": "^13.1.0",
     "eslint-plugin-license-header": "^0.9.0",
     "libphonenumber-js": "^1.12.7",

--- a/src/client/createSeamlessAuthClient.ts
+++ b/src/client/createSeamlessAuthClient.ts
@@ -17,12 +17,17 @@ import {
 import type {
   AddOrganizationMemberRequest,
   CreateOrganizationRequest,
+  CredentialUpdateResponse,
   LoginMethod as LoginMethodShape,
   LoginSuccessResponse,
   LogoutScope as LogoutScopeShape,
   MeResponse,
   MessageResponse,
+  OAuthProvidersResponse,
+  OrganizationEnvelopeResponse,
   OrganizationListResponse,
+  OrganizationMembersResponse,
+  OrganizationMembershipEnvelopeResponse,
   OrganizationSwitchResponse,
   PublicOAuthProvider,
   RegistrationRequest,
@@ -36,7 +41,6 @@ import type {
 } from '@seamless-auth/types';
 
 import { createFetchWithAuth } from '../fetchWithAuth';
-import { Credential, Organization, OrganizationMembership } from '../types';
 import { getWebAuthnErrorDetail } from './errors';
 import {
   NETWORK_ERROR_STATUS,
@@ -97,19 +101,12 @@ export type OrganizationMemberUpdateInput = UpdateOrganizationMemberRequest;
 
 export type OrganizationsResult = OrganizationListResponse;
 
-export interface OrganizationResult {
-  organization: Organization;
-}
+export type OrganizationResult = OrganizationEnvelopeResponse;
 
-export interface OrganizationMembersResult {
-  members: OrganizationMembership[];
-  total: number;
-}
+export type OrganizationMembersResult = OrganizationMembersResponse;
 
 /** Response body for a single membership mutation. */
-export interface OrganizationMembershipResult {
-  membership: OrganizationMembership;
-}
+export type OrganizationMembershipResult = OrganizationMembershipEnvelopeResponse;
 
 /**
  * Response body when the active organization changes, minus its session
@@ -122,9 +119,7 @@ export type OrganizationSwitchResult = Omit<
 
 export type OAuthProvider = PublicOAuthProvider;
 
-export interface OAuthProvidersResult {
-  providers: OAuthProvider[];
-}
+export type OAuthProvidersResult = OAuthProvidersResponse;
 
 export interface StartOAuthLoginInput {
   providerId: string;
@@ -155,10 +150,7 @@ export interface PasskeyRegistrationData {
 }
 
 /** Response body returned when credential metadata is updated. */
-export interface CredentialUpdateResult {
-  message: string;
-  credential: Credential;
-}
+export type CredentialUpdateResult = CredentialUpdateResponse;
 
 export interface RegisterPasskeyOptions {
   metadata: PasskeyMetadata;

--- a/tests/wireTypes.test.ts
+++ b/tests/wireTypes.test.ts
@@ -6,8 +6,13 @@
 
 import type { Credential, Organization, User } from '@/types';
 import type {
+  CredentialUpdateResult,
   LoginStartResult,
   MessageResult,
+  OAuthProvidersResult,
+  OrganizationMembersResult,
+  OrganizationMembershipResult,
+  OrganizationResult,
   OrganizationSwitchResult,
   StepUpStatus,
 } from '@/client/createSeamlessAuthClient';
@@ -56,6 +61,28 @@ describe('wire types match what the API sends', () => {
     expect(login.token).toBeUndefined();
     // @ts-expect-error the switch result must not advertise a session id
     expect(organizationSwitch.sessionId).toBeUndefined();
+  });
+
+  // These five were declared by hand until the package exported aliases for them
+  // (seamless-auth-types#10). Pinning the envelopes keeps that from creeping back.
+  it('takes the response envelopes from the package', () => {
+    const providers = {} as OAuthProvidersResult;
+    const organization = {} as OrganizationResult;
+    const members = {} as OrganizationMembersResult;
+    const membership = {} as OrganizationMembershipResult;
+    const credentialUpdate = {} as CredentialUpdateResult;
+
+    const providerId: string | undefined = providers.providers?.[0]?.id;
+    const total: number = members.total;
+    const lastUsedAt: string | null | undefined = credentialUpdate.credential?.lastUsedAt;
+
+    expect([
+      providerId,
+      organization.organization,
+      membership.membership,
+      total,
+      lastUsedAt,
+    ]).toHaveLength(5);
   });
 
   it('keeps the acknowledgement and step-up shapes intact', () => {


### PR DESCRIPTION
Follow-up to #117, closing both gaps it left open. fells-code/seamless-auth-types#10 shipped in types 0.4.0, and 0.3.0 added a Zod-free entry point for role matching.

## 1. Response envelopes (types 0.4.0)

Five response bodies stayed hand-written in #117 because the package shipped schemas for them without exported type aliases. 0.4.0 exports a `z.infer` alias for every schema (all 43 that lacked one) and guards it with a test upstream, so these become aliases like the rest of the wire contract:

- `OAuthProvidersResult`
- `CredentialUpdateResult`
- `OrganizationResult`
- `OrganizationMembersResult`
- `OrganizationMembershipResult`

I checked each upstream shape against the local declaration before swapping; they match, so this part is a no-op for adopters. `src/client/createSeamlessAuthClient.ts` no longer imports the local domain types at all.

## 2. Role matching (types 0.3.0)

`hasScopedRole()` and `roleGrantsAccess()` were implemented here and again upstream, so the SDK could drift from the rules the API enforces. `src/scopedRoles.ts` now re-exports the package's `role/matching` subpath and stays the SDK's export boundary, so adopters keep importing both from `@seamless-auth/react`.

**Behavior was compared, not assumed.** A temporary differential test ran both implementations across 476,100 granted/required role pairs from a generated corpus (including whitespace, casing, `:*` suffixes, and empty segments), plus non-array and mixed-type inputs to `hasScopedRole`. Zero disagreements. The existing scoped-role tests now cover the shared implementation.

## The runtime import, and keeping it honest

This is the package's only runtime import, so the bundle purity that made this dependency safe in #117 is now enforced rather than documented:

- a lint rule rejects value imports from the `@seamless-auth/types` barrel and allows type imports. I verified it fires by flipping one `import type` back to a value import.
- `@seamless-auth/types/role/matching` is declared external in the rollup config, so it resolves at the consumer rather than being inlined.
- the built bundle contains no Zod, and the subpath module has zero import statements of its own.
- the subpath resolves and behaves correctly from a clean consumer install on plain Node ESM, which I checked directly.

ESM-only is not a new constraint for adopters: this package already publishes ESM with an `import` condition and no `require`, exactly like the dependency.

Jest is the one place that needed work, because its CommonJS resolver will not follow the package's ESM subpath exports. `jest.config.ts` maps the subpath directly and exempts the package from `transformIgnorePatterns`. Widening `customExportConditions` was the obvious fix and the wrong one: it pushes unrelated dependencies onto ESM builds the test runtime cannot parse, which is recorded in the config comment and in AGENTS.md so it does not get retried.

## Validation

`npm run lint`, `npm run typecheck`, `npm run format:check`, `npm test -- --runInBand` (269 passing across 31 suites), `npm run build`, and `npm run check-npm-build` all pass.