### PR TITLE
fix(provider): keep the session store alive across a remount

### DIFF
--- a/.changeset/nine-pans-shake.md
+++ b/.changeset/nine-pans-shake.md
@@ -5,3 +5,5 @@
 Stop calling the logout endpoint when the session check fails. A failed `/users/me` means the server already considers the session unusable, so the SDK now clears it locally instead of sending a `DELETE /logout` for a session that does not exist. Previously every anonymous page load fired that second request.
 
 Session state now lives in a framework-agnostic store behind `AuthProvider`, which reads it through `useSyncExternalStore`. The provider's public API is unchanged. Reading a previous sign-in goes through a storage port that falls back to memory when there is no `localStorage`, so the store is safe to create during server-side rendering.
+
+The store survives a remount. React can run mount, cleanup, mount against the same provider, which StrictMode does on every mount and Activity does whenever a hidden tree is shown again, so the provider no longer destroys the store from its effect cleanup. `destroy()` is terminal, and tearing it down there left the remounted provider holding a store that refused every update and stayed on `loading: true`.

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -115,12 +115,19 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     session.getState
   );
 
+  // The store is deliberately not destroyed on cleanup. `destroy()` is terminal,
+  // and React may run mount, cleanup, mount against the same memoized store:
+  // StrictMode does it on every mount today, and Activity will do it whenever a
+  // tree is hidden and shown again. Tearing down here left the remounted provider
+  // holding a store that refuses updates, stuck on `loading: true` forever.
+  //
+  // Nothing leaks by skipping it. `useSyncExternalStore` removes its own listener
+  // when the provider unmounts, and the store owns no timers or subscriptions, so
+  // it is reclaimed with the component. A refresh still in flight then resolves
+  // into a store nobody observes. `destroy()` stays on the store for bindings that
+  // genuinely own its lifetime.
   useEffect(() => {
     void session.actions.refreshSession();
-
-    return () => {
-      session.destroy();
-    };
   }, [session]);
 
   const value = useMemo(

--- a/tests/authProvider.test.tsx
+++ b/tests/authProvider.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
 import { AuthProvider, useAuth } from '../src/AuthProvider';
 import { createFetchWithAuth } from '../src/fetchWithAuth';
 
@@ -23,6 +24,7 @@ const Consumer = () => {
     <div>
       <span data-testid="user">{auth.user ? auth.user.email : 'none'}</span>
       <span data-testid="isAuthenticated">{String(auth.isAuthenticated)}</span>
+      <span data-testid="loading">{String(auth.loading)}</span>
       <span data-testid="hasRoleAdmin">{String(auth.hasRole('admin'))}</span>
       <span data-testid="hasScopedRoleAdminRead">
         {String(auth.hasScopedRole('admin:read'))}
@@ -461,6 +463,64 @@ describe('AuthProvider', () => {
     expect(returned.data).toEqual(updatedCredential);
     expect(returned.data?.friendlyName).toBe('Renamed passkey');
     expect(returned.data).not.toHaveProperty('message');
+  });
+
+  // StrictMode runs mount, cleanup, mount while useMemo keeps the same session
+  // store, so a provider that tore the store down on cleanup came back holding a
+  // store that refused every update and never left `loading`. The templates ship
+  // StrictMode, so this is the default path for a new app, not an edge case.
+  describe('StrictMode remount', () => {
+    it('settles a signed-out session instead of loading forever', async () => {
+      // The adapter answers a missing access cookie with 400, which is the
+      // ordinary anonymous first load.
+      mockFetchWithAuthImpl.mockResolvedValue(
+        failure(400, { error: 'Missing required cookie "seamless-access"' })
+      );
+
+      await act(async () => {
+        render(
+          <StrictMode>
+            <AuthProvider apiHost={apiHost}>
+              <Consumer />
+            </AuthProvider>
+          </StrictMode>
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('false');
+      });
+
+      expect(screen.getByTestId('isAuthenticated')).toHaveTextContent('false');
+      expect(screen.getByTestId('user')).toHaveTextContent('none');
+    });
+
+    it('still loads an authenticated session', async () => {
+      mockFetchWithAuthImpl.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          user: { id: '1', email: 'test@example.com', phone: '', roles: ['admin'] },
+          credentials: [],
+        }),
+      } as any);
+
+      await act(async () => {
+        render(
+          <StrictMode>
+            <AuthProvider apiHost={apiHost}>
+              <Consumer />
+            </AuthProvider>
+          </StrictMode>
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('user')).toHaveTextContent('test@example.com');
+      });
+
+      expect(screen.getByTestId('loading')).toHaveTextContent('false');
+      expect(screen.getByTestId('isAuthenticated')).toHaveTextContent('true');
+    });
   });
 
   describe('failure paths', () => {


### PR DESCRIPTION
## Problem

`AuthProvider` creates the session store in `useMemo` but destroys it in a `useEffect` cleanup. Those have different lifetimes. React can run mount, cleanup, mount against the same memoized value: StrictMode does it on every mount, and Activity does it whenever a hidden tree is shown again.

`destroy()` is terminal by design, so the remounted provider held a store that refused every update. `refreshSession` then returned early at its `destroyed` guard before it could set `loading: false`, and `loading` stayed `true` forever.

Any app rendering the provider inside `StrictMode`, which is what `templates/web/react-vite` ships, never left its loading state. That applies to an authenticated session as much as an anonymous one, so it was not limited to signed-out first loads.

Found while running the react-vite and express templates against local `main` of every repo. The app sat on "Checking your session..." indefinitely.

## Fix

The provider no longer destroys the store from its effect cleanup.

Nothing leaks by skipping it. `useSyncExternalStore` removes its own listener when the provider unmounts, and the store owns no timers or subscriptions, so it is reclaimed with the component. A refresh still in flight resolves into a store nobody observes.

`destroy()` stays on the store. Its terminal semantics are intentional and covered by `authSession.test.ts`, and a binding that genuinely owns the store's lifetime still needs it.

The store's contract was sound, so the fix is in the binding that misused it rather than in `createAuthSession` or in the adapter's response code.

## Notes

The 400 that `@seamless-auth/core` returns for a missing `seamless-access` cookie is arguably better as a 401, since an absent cookie is the ordinary anonymous case. It is not what broke this, and changing it is a cross-repo contract change, so it is left alone here.

No public API change. The session store is not exported from `src/index.ts`, and `dist/index.d.ts` is unchanged.

The bug is unreleased: `src/session` does not exist in `v0.6.0`, so no published version is affected. Rather than add a changeset describing a bug no user ever saw, the pending `nine-pans-shake.md` changeset that introduced the store gained a paragraph on the remount behavior.

## Verification

Both new tests fail on the previous behavior and pass on this branch.

- `npm run typecheck`, `npm run lint`, `npm run format:check`: clean
- `npm test -- --runInBand`: 271 passed, 31 suites, coverage thresholds met
- `npm run build`, `npm run check-npm-build`: clean

Also exercised end to end against a local stack (auth API from source, express template, react-vite template) with `StrictMode` in place: registration, email OTP, and a signed-in session surviving a full page reload.

`Activity` is the same mechanism and the same fix, but only the `StrictMode` path was exercised.
