### PR TITLE
fix(oauth): read the OAuth error code from a nested details object

### DIFF
--- a/.changeset/lemon-doors-listen.md
+++ b/.changeset/lemon-doors-listen.md
@@ -1,0 +1,5 @@
+---
+'@seamless-auth/react': patch
+---
+
+Read the OAuth failure code from a nested `details` object when the error body does not carry it at the top level. `getOAuthErrorCode` only looked at a top-level `code`, which is where the auth API puts it, so a proxy that normalized the error body and moved the siblings of `error` under `details` silently downgraded OAuth messaging to a generic failure. Both locations are accepted now, the top level still wins, and the allowlist is unchanged: an unrecognized code in either place still returns `undefined`.

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -46,10 +46,23 @@ const OAUTH_ERROR_CODES: Record<OAuthErrorCode, true> = {
   oauth_missing_subject: true,
 };
 
+function readCode(body: unknown): unknown {
+  if (typeof body !== 'object' || body === null) {
+    return undefined;
+  }
+
+  return (body as { code?: unknown }).code;
+}
+
 /**
  * Read the OAuth failure code off a result error. Returns `undefined` for
  * anything unrecognized, including codes added by a newer API, so callers keep
  * their generic messaging instead of showing a raw code.
+ *
+ * The auth API puts `code` at the top level of the error body, but a proxy in
+ * front of it may normalize that body and nest the siblings of `error` under
+ * `details`. Both locations are accepted so such a proxy does not silently
+ * downgrade OAuth messaging to a generic failure.
  */
 export function getOAuthErrorCode(error: unknown): OAuthErrorCode | undefined {
   if (!(error instanceof SeamlessAuthError)) {
@@ -60,7 +73,8 @@ export function getOAuthErrorCode(error: unknown): OAuthErrorCode | undefined {
     return undefined;
   }
 
-  const { code } = error.body as { code?: unknown };
+  const code =
+    readCode(error.body) ?? readCode((error.body as { details?: unknown }).details);
 
   return typeof code === 'string' &&
     Object.prototype.hasOwnProperty.call(OAUTH_ERROR_CODES, code)

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -83,9 +83,38 @@ describe('getOAuthErrorCode', () => {
     }
   );
 
+  it.each(['oauth_missing_email', 'oauth_email_not_verified', 'oauth_missing_subject'])(
+    'returns the known code %s nested under details',
+    code => {
+      const error = new SeamlessAuthError('Sign-in failed', 400, {
+        error: 'Sign-in failed',
+        details: { code },
+      });
+
+      expect(getOAuthErrorCode(error)).toBe(code);
+    }
+  );
+
+  it('prefers the top-level code over the nested one', () => {
+    const error = new SeamlessAuthError('Sign-in failed', 400, {
+      code: 'oauth_missing_email',
+      details: { code: 'oauth_missing_subject' },
+    });
+
+    expect(getOAuthErrorCode(error)).toBe('oauth_missing_email');
+  });
+
   it('ignores a code the SDK does not know', () => {
     const error = new SeamlessAuthError('Sign-in failed', 400, {
       code: 'oauth_something_new',
+    });
+
+    expect(getOAuthErrorCode(error)).toBeUndefined();
+  });
+
+  it('ignores a nested code the SDK does not know', () => {
+    const error = new SeamlessAuthError('Sign-in failed', 400, {
+      details: { code: 'oauth_something_new' },
     });
 
     expect(getOAuthErrorCode(error)).toBeUndefined();
@@ -97,10 +126,36 @@ describe('getOAuthErrorCode', () => {
     ).toBeUndefined();
   });
 
+  it('returns undefined when details carries no code', () => {
+    expect(
+      getOAuthErrorCode(
+        new SeamlessAuthError('Sign-in failed', 400, {
+          error: 'nope',
+          details: { requestId: 'abc' },
+        })
+      )
+    ).toBeUndefined();
+  });
+
   it('returns undefined for a missing or non-object body', () => {
     expect(getOAuthErrorCode(new SeamlessAuthError('nope', 500))).toBeUndefined();
     expect(
+      getOAuthErrorCode(new SeamlessAuthError('nope', 500, undefined))
+    ).toBeUndefined();
+    expect(getOAuthErrorCode(new SeamlessAuthError('nope', 500, null))).toBeUndefined();
+    expect(
       getOAuthErrorCode(new SeamlessAuthError('nope', 500, 'oauth_missing_email'))
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for a non-object details', () => {
+    expect(
+      getOAuthErrorCode(
+        new SeamlessAuthError('nope', 500, { details: 'oauth_missing_email' })
+      )
+    ).toBeUndefined();
+    expect(
+      getOAuthErrorCode(new SeamlessAuthError('nope', 500, { details: null }))
     ).toBeUndefined();
   });
 


### PR DESCRIPTION
Closes #120

`getOAuthErrorCode` read the OAuth failure code from a top-level `code` key on the parsed error body, which is where the auth API puts it (`{ error, message?, code? }`, see `src/schemas/oauth.responses.ts` in `seamless-auth-api`). That hard-coupled the SDK to the API's exact top-level shape: any intermediary that normalized the error body broke OAuth messaging silently, because `code` read as `undefined` and the UI fell back to a generic error instead of the user-actionable message.

That already happened in practice. https://github.com/fells-code/seamless-auth-server/pull/124 had to forward auth API error bodies verbatim specifically because normalizing them (moving the siblings of `error` under a `details` object) broke this function, and that constraint now blocks cleanup work in that repo.

## Change

`getOAuthErrorCode` now accepts the code in either location: the top level first, exactly as before, then a nested `details` object when the top level does not carry one. Everything else is unchanged, including the public signature and the allowlist, so an unrecognized code in either place still returns `undefined` and callers keep their generic messaging.

## Tests

Added coverage in `tests/errors.test.ts` for each known code nested under `details`, top level winning when both are present, an unrecognized code in each location, `details` present without a code, a null/undefined/non-object body, and a non-object `details`.

## Checks

`npm test -- --runInBand` (31 suites, 276 tests passing), `npm run typecheck`, `npm run lint`, `npm run format:check`, and `npm run build` all pass locally.

Patch changeset included since this changes user-facing behavior for adopters behind a normalizing proxy.
