### PR TITLE
chore(deps): move onto @seamless-auth/types 0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@seamless-auth/react",
-  "version": "0.7.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@seamless-auth/react",
-      "version": "0.7.0",
+      "version": "0.9.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@seamless-auth/types": "^0.5.0",
+        "@seamless-auth/types": "^0.16.0",
         "@simplewebauthn/browser": "^13.1.0",
         "eslint-plugin-license-header": "^0.9.0",
         "libphonenumber-js": "^1.12.7",
@@ -3066,9 +3066,9 @@
       "license": "MIT"
     },
     "node_modules/@seamless-auth/types": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@seamless-auth/types/-/types-0.5.0.tgz",
-      "integrity": "sha512-T566YQu8FqUmqgte0A0iJpjTDXUKq/d/7uvLlXGXKtdl52Edo0r3iafL3kx4OM0cRJM63tBGe9s4MTjRUth6yA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@seamless-auth/types/-/types-0.16.0.tgz",
+      "integrity": "sha512-7W8w850S5B+6nekeIMG9Cmmouo6ABnoQ7iUpO62GG08HGx2Ur5j14pFB2CFs0MQWIQss5mcMkNPSY2NfB0UoNA==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "dependencies": {
-    "@seamless-auth/types": "^0.5.0",
+    "@seamless-auth/types": "^0.16.0",
     "@simplewebauthn/browser": "^13.1.0",
     "eslint-plugin-license-header": "^0.9.0",
     "libphonenumber-js": "^1.12.7",

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -4,7 +4,10 @@
  * See LICENSE file in the project root for full license information
  */
 
-import type { OAuthErrorCode as OAuthErrorCodeShape } from '@seamless-auth/types';
+import type {
+  OAuthErrorCode as OAuthErrorCodeShape,
+  WebAuthnErrorCode as WebAuthnErrorCodeShape,
+} from '@seamless-auth/types';
 
 /**
  * Error carrying the auth server's response detail, so callers can map known
@@ -86,17 +89,23 @@ export function getOAuthErrorCode(error: unknown): OAuthErrorCode | undefined {
  * Machine-readable codes `POST /webAuthn/register/finish` answers `403` with
  * when a deployment refuses an otherwise valid credential on policy grounds.
  */
-export type PasskeyPolicyErrorCode =
-  | 'synced_passkey_not_allowed'
-  | 'authenticator_not_allowed'
-  | 'prf_required';
+export type PasskeyPolicyErrorCode = Extract<
+  WebAuthnErrorCodeShape,
+  'synced_passkey_not_allowed' | 'authenticator_not_allowed' | 'prf_required'
+>;
 
 /*
- * Unlike the OAuth codes, `@seamless-auth/types` publishes no union for these
- * (checked against 0.15.0), so this list is a copy of the API's rather than a
- * check against it and will not fail to compile if the API adds a code. Drift
- * therefore degrades to generic messaging instead of breaking; the `Record`
- * still keeps the list and the union in step with each other.
+ * `WebAuthnErrorCode` covers every WebAuthn code the API sends, across all of
+ * its operations, so it is deliberately narrowed rather than used whole. The
+ * two it leaves out belong to other calls and other statuses:
+ * `attachment_not_allowed` is a `400` from register/start, and
+ * `prf_output_not_allowed` a `400` from login and step-up finish. Reporting
+ * either as a registration policy refusal would be wrong.
+ *
+ * `Extract` still ties the three names to the upstream union: if one is renamed
+ * or dropped there, it resolves to `never` and the `Record` below stops
+ * compiling. As with the OAuth codes, the runtime list stays out of the browser
+ * bundle so Zod does not come with it.
  */
 const PASSKEY_POLICY_ERROR_CODES: Record<PasskeyPolicyErrorCode, true> = {
   synced_passkey_not_allowed: true,

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -8,6 +8,7 @@ import {
   getOAuthErrorCode,
   getPasskeyPolicyErrorCode,
   getWebAuthnErrorDetail,
+  type PasskeyPolicyErrorCode,
   SeamlessAuthError,
   toSeamlessAuthError,
 } from '@/client/errors';
@@ -168,7 +169,7 @@ describe('getOAuthErrorCode', () => {
 });
 
 describe('getPasskeyPolicyErrorCode', () => {
-  const policyCodes = [
+  const policyCodes: PasskeyPolicyErrorCode[] = [
     'synced_passkey_not_allowed',
     'authenticator_not_allowed',
     'prf_required',
@@ -188,6 +189,18 @@ describe('getPasskeyPolicyErrorCode', () => {
 
     expect(getPasskeyPolicyErrorCode(error)).toBe(code);
   });
+
+  // These are WebAuthn codes from other operations: `attachment_not_allowed` is
+  // a 400 from register/start, `prf_output_not_allowed` a 400 from login and
+  // step-up finish. Neither is a registration policy refusal.
+  it.each(['attachment_not_allowed', 'prf_output_not_allowed'])(
+    'ignores %s, which is not a registration policy refusal',
+    code => {
+      const error = new SeamlessAuthError(code, 400, { error: code });
+
+      expect(getPasskeyPolicyErrorCode(error)).toBeUndefined();
+    }
+  );
 
   it('reads a real refusal built from the API response', async () => {
     const error = await toSeamlessAuthError(


### PR DESCRIPTION
## Summary

Moves `@seamless-auth/types` from `^0.5.0` to `^0.16.0`, and uses the union that
0.16.0 publishes.

0.16.0 adds `WebAuthnErrorCode`, a union of the machine-readable codes the auth
API returns as the whole of an error body's `error` field. `PasskeyPolicyErrorCode`
was a hand-maintained copy of three of those names, because when #132 was built
there was no upstream union to check it against. That issue asked for the same
`Record` exhaustiveness check the OAuth codes get, and settled for a copy with a
comment saying so ("checked against 0.15.0"). This replaces the copy with
`Extract<WebAuthnErrorCode, ...>`, so renaming or dropping any of the three
upstream resolves the type to `never` and stops the `Record` compiling.

Verified that guard rather than assuming it: simulating an upstream rename
produced `TS2353` in `errors.ts` and `TS2322` in the test.

## The union is narrowed, not adopted whole

`WebAuthnErrorCode` spans every WebAuthn operation, so taking it whole would be
wrong. Checked against `seamless-auth-api` `main`:

| Code | Route | Status |
| --- | --- | --- |
| `synced_passkey_not_allowed` | `POST /webauthn/register/finish` | 403 |
| `authenticator_not_allowed` | `POST /webauthn/register/finish` | 403 |
| `prf_required` | `POST /webauthn/register/finish` | 403 |
| `attachment_not_allowed` | `GET /webauthn/register/start` | 400 |
| `prf_output_not_allowed` | `login/finish`, `step-up/webauthn/finish` | 400 |

The existing three are exactly the registration policy refusals: `webauthn.ts`
sends `verdict.reason` (typed `AuthenticatorRefusal`, the two policy codes) and
`prf_required`, both `403`, from `verifyWebAuthnRegistration`.

The other two are different operations at a different status. `prf_output_not_allowed`
is a server-side guard against a client that fails to strip PRF output before
posting, so reporting it as a deployment policy refusal would point an integrator
at their config when the real cause is a client bug. Both are also unreachable
through this SDK today: the API only sends `attachment_not_allowed` when the
caller requests an attachment, and `buildRegisterStartPath` only ever sets
`requestPrf` and `requirePrf`; the SDK calls `stripPrfResultsFromAssertion` at
all three assertion sites. A test pins both as ignored so the narrowing is
enforced rather than only explained in a comment.

## Rest of the range

No other changes were needed. The two breaking changes between 0.5.0 and 0.16.0,
`RegistrationSuccessSchema.ttl` becoming a number (0.6.0) and
`DeviceReplacementRecoverySchema` requiring `proofing` (0.9.0), are both unused
here. Everything else was additive. `aaguid` (0.12.0) reaches the public
`Credential` type for free through `CredentialResponse`, and
`PublicSystemConfigResponse` is still just `{ loginMethods }`, so there is still
no way for a client to pre-check authenticator policy.

Related: fells-code/seamless-auth-api#183 covers the `attachment` gap noted
above, where the API accepts a parameter the SDK never sends. Not addressed here.

## Type of Change

- [x] Refactor
- [ ] Feature
- [ ] Fix
- [ ] Documentation
- [ ] Test

## Release Impact

- [ ] Changeset added for adopter-facing package change
- [x] No package release expected

No changeset, matching c206f29 (`chore(deps): move onto @seamless-auth/types 0.5.0`),
which bumped the same dependency without one. Nothing here is adopter-facing: the
recognized codes, the return type, and the fallback to `undefined` are unchanged.
Say the word if you would rather it carried one.

## Checklist

- [x] Tests pass
- [x] No breaking changes
- [ ] Changeset summary is clear for SDK adopters
- [x] Docs updated (if needed)
- [x] Security implications considered

README needed no change: it documents the three registration refusal codes, which
is still the exact set this recognizes.

`npm run typecheck`, `npm test` (305 passing), `npm run lint`, `npm run format:check`
and `npm run build` all pass.
