### PR TITLE
feat(magic-link): let a caller choose where the link lands

### DIFF
--- a/.changeset/great-owls-travel.md
+++ b/.changeset/great-owls-travel.md
@@ -1,0 +1,21 @@
+---
+'@seamless-auth/react': minor
+---
+
+Let a caller choose where a magic link lands.
+
+`requestMagicLink` takes an optional `redirectUri`. A deployment serving both a web
+app and a mobile app previously had one destination for every magic link, so a link
+had to arrive in one or the other.
+
+The value goes in the request body the client already sends. The deployment validates
+it against its configured origins and refuses anything else, so this cannot be used to
+point a link on the tenant's domain somewhere it should not go, and a refusal comes
+back as an ordinary error result.
+
+Omit it and nothing changes: the same empty body is sent, so the destination stays the
+deployment's own and no caller has to do anything.
+
+Needs a `@seamless-auth/server` adapter that forwards the field and an auth API that
+understands it. Against older versions the value is dropped and the link keeps the
+deployment's destination, which is the behaviour today.

--- a/src/client/createSeamlessAuthClient.ts
+++ b/src/client/createSeamlessAuthClient.ts
@@ -243,7 +243,13 @@ export interface SeamlessAuthClient {
   verifyLoginEmailOtp: (
     verificationToken: string
   ) => Promise<SeamlessAuthResult<MessageResult>>;
-  requestMagicLink: () => Promise<SeamlessAuthResult<MessageResult>>;
+  /**
+   * @param redirectUri Where the emailed link should land. The deployment validates
+   * it against its configured origins and refuses anything else, so a tenant serving
+   * a web app and a mobile app can send each to its own destination. Omit it to keep
+   * the deployment's single destination.
+   */
+  requestMagicLink: (redirectUri?: string) => Promise<SeamlessAuthResult<MessageResult>>;
   checkMagicLink: () => Promise<SeamlessAuthResult<MessageResult>>;
   verifyMagicLink: (token: string) => Promise<SeamlessAuthResult<MessageResult>>;
   listOAuthProviders: () => Promise<SeamlessAuthResult<OAuthProvidersResult>>;
@@ -575,12 +581,15 @@ export const createSeamlessAuthClient = (
         'Failed to verify the email code.'
       ),
 
-    // Sends an empty JSON body on purpose. The adapter ignores it, but it makes
-    // fetchWithAuth declare a JSON content type, which forces a CORS preflight.
-    // A bodyless POST is still a simple request and stays reachable cross-site.
-    requestMagicLink: () =>
+    // The body is sent even when it is empty, so fetchWithAuth declares a JSON
+    // content type and the request takes a CORS preflight. A bodyless POST is a
+    // simple request and stays reachable cross-site.
+    requestMagicLink: redirectUri =>
       requestResult<MessageResult>(
-        fetchWithAuth(`/magic-link`, { method: 'POST', body: JSON.stringify({}) }),
+        fetchWithAuth(`/magic-link`, {
+          method: 'POST',
+          body: JSON.stringify(redirectUri ? { redirectUri } : {}),
+        }),
         'Failed to send the magic link.'
       ),
 

--- a/tests/createSeamlessAuthClient.test.ts
+++ b/tests/createSeamlessAuthClient.test.ts
@@ -200,6 +200,44 @@ describe('createSeamlessAuthClient', () => {
     });
   });
 
+  it('sends a requested destination for the magic link', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: 'Success' }),
+    });
+
+    const client = createSeamlessAuthClient({
+      apiHost: 'https://api.example.com',
+    });
+
+    expect(
+      (await client.requestMagicLink('https://app.example.com/magic')).error
+    ).toBeNull();
+
+    expect(mockFetchWithAuth).toHaveBeenCalledWith('/magic-link', {
+      method: 'POST',
+      body: JSON.stringify({ redirectUri: 'https://app.example.com/magic' }),
+    });
+  });
+
+  // The deployment owns the allowlist, so a refusal is reported rather than
+  // pre-empted here. Guessing at it in the client would mean two allowlists.
+  it('reports a destination the deployment refuses', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'Redirect URI is not allowed' }),
+    });
+
+    const client = createSeamlessAuthClient({
+      apiHost: 'https://api.example.com',
+    });
+
+    const { error } = await client.requestMagicLink('https://evil.example/steal');
+
+    expect(error).not.toBeNull();
+  });
+
   it('keeps an untrusted magic-link token inside its own path segment', async () => {
     mockFetchWithAuth.mockResolvedValue({
       ok: true,


### PR DESCRIPTION
Last of three. fells-code/seamless-auth-api#240 added `redirectUri` to the magic link request, fells-code/seamless-auth-server#151 taught the adapter to forward it, and nothing in this SDK could supply one, so an end-user app still had a single destination for every magic link.

## What changed

`requestMagicLink` takes an optional `redirectUri`, carried in the request body the client already sends:

```ts
await authClient.requestMagicLink('https://app.example.com/magic');
```

**Additive.** Omit it and the same empty body goes out, so the default path is byte for byte unchanged and no caller has to do anything. Against an older adapter or API the field is dropped and the link keeps the deployment's destination.

## Not validated here

The deployment owns the allowlist. It checks the value against its configured origins and answers `400`, which surfaces as an ordinary error result. An allowlist kept in two places is one that eventually disagrees with itself, so the client reports the refusal rather than guessing at it. There is a test for that.

## A comment that had gone stale

The empty body carried this:

> Sends an empty JSON body on purpose. The adapter ignores it, but it makes `fetchWithAuth` declare a JSON content type, which forces a CORS preflight.

"The adapter ignores it" stopped being true the moment the adapter started reading `redirectUri`. Reworded to explain only the part that still holds, which is the preflight, since that is the load-bearing reason the body exists at all (a bodyless POST is a simple request, and a GET here was CSRF-able).

## Bundled views left alone

`Login.tsx` and `MagicLinkSent.tsx` still call `requestMagicLink()` with no argument, so their behaviour is unchanged. A destination is app configuration rather than something a user picks in a form, and the headless client path is where it belongs. Worth revisiting if the bundled views ever need to target a mobile build.

## Verification

`npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build` all clean. 317 tests passing across 32 suites, 2 of them new. Verified non-vacuous: reverting the client to always send `{}` fails the new forwarding test.

## Order

The other two are merged, so this completes the chain and the feature works end to end once this is released alongside them.